### PR TITLE
[codex] Add SSE fixtures and API regression coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ Provides a simple, modern, example API for demoing or debugging various features
 - Conditional requests via `ETag` or `LastModified`
 - Echo back request info to help debugging
 - Cached responses to test proxy & client-side caching
+- Auth, form, multipart upload, redirect, retry, timeout, cookie, and header fixtures
 - Example structured data
   - Shows off `object`, `array`, `string`, `date`, `binary`, `integer`, `number`, `boolean`, etc.
 - A sample CRUD API for books & reviews with simulated server-side updates
+- A resettable sample CRUD API for docs-oriented item examples
 - Image responses `JPEG`, `WEBP`, `GIF`, `PNG` & `HEIC`
+- [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) and NDJSON streaming with JSON events
+- Byte streams, range requests, explicit compression fixtures, and content negotiation examples
 - [RFC7807](https://datatracker.ietf.org/doc/html/rfc7807) structured errors
 
 This project is open source: https://github.com/danielgtaylor/apibin

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,718 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/autopatch"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/go-chi/chi/v5"
+	"gopkg.in/yaml.v2"
+)
+
+func newTestAPI(t *testing.T) humatest.TestAPI {
+	t.Helper()
+
+	config := huma.DefaultConfig("Test API", "1.0.0")
+	yamlFormat := huma.Format{
+		Marshal: func(writer io.Writer, v any) error {
+			return yaml.NewEncoder(writer).Encode(v)
+		},
+		Unmarshal: func(data []byte, v any) error {
+			return yaml.Unmarshal(data, v)
+		},
+	}
+	config.Formats["application/yaml"] = yamlFormat
+	config.Formats["yaml"] = yamlFormat
+
+	router := chi.NewMux()
+	router.Use(ContentEncoding)
+	api := humatest.Wrap(t, humachi.New(router, config))
+
+	server := APIServer{}
+	huma.AutoRegister(api, &server)
+	autopatch.AutoPatch(api)
+	return api
+}
+
+func assertStatus(t *testing.T, resp *httptest.ResponseRecorder, status int) {
+	t.Helper()
+	if resp.Code != status {
+		t.Fatalf("status = %d, want %d; body: %s", resp.Code, status, resp.Body.String())
+	}
+}
+
+func assertHeader(t *testing.T, resp *httptest.ResponseRecorder, name, want string) {
+	t.Helper()
+	if got := resp.Header().Get(name); got != want {
+		t.Fatalf("%s = %q, want %q; body: %s", name, got, want, resp.Body.String())
+	}
+}
+
+func decodeJSON(t *testing.T, resp *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var data map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &data); err != nil {
+		t.Fatalf("invalid JSON body: %v\n%s", err, resp.Body.String())
+	}
+	return data
+}
+
+func TestETagHelpersAndConditionals(t *testing.T) {
+	for name, tag := range map[string]string{
+		"generated": quoteETag(genETagBytes([]byte("hello"))),
+		"book":      quoteETag(Book{Title: "Example"}.Version()),
+	} {
+		if !strings.HasPrefix(tag, `"`) || !strings.HasSuffix(tag, `"`) {
+			t.Fatalf("%s ETag is not quoted: %q", name, tag)
+		}
+	}
+
+	api := newTestAPI(t)
+	resp := api.Get("/books/letters-from-an-astrophysicist")
+	assertStatus(t, resp, http.StatusOK)
+	etag := resp.Header().Get("ETag")
+	if !strings.HasPrefix(etag, `"`) || !strings.HasSuffix(etag, `"`) {
+		t.Fatalf("response ETag is not quoted: %q", etag)
+	}
+
+	resp = api.Get("/books/letters-from-an-astrophysicist", "If-None-Match: "+etag)
+	assertStatus(t, resp, http.StatusNotModified)
+
+	resp = api.Get("/etag/docs")
+	assertStatus(t, resp, http.StatusOK)
+	assertHeader(t, resp, "ETag", `"docs"`)
+
+	resp = api.Get("/etag/docs", `If-None-Match: "docs"`)
+	assertStatus(t, resp, http.StatusNotModified)
+
+	resp = api.Get("/cache", "If-Modified-Since: Tue, 01 Feb 2022 12:34:56 GMT")
+	assertStatus(t, resp, http.StatusNotModified)
+}
+
+func TestCoreContentAndInspectionEndpoints(t *testing.T) {
+	api := newTestAPI(t)
+
+	resp := api.Get("/example")
+	assertStatus(t, resp, http.StatusOK)
+	assertHeader(t, resp, "ETag", quoteETag(exampleEtag))
+	if !strings.Contains(resp.Body.String(), "basics") {
+		t.Fatalf("example response missing basics: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/types")
+	assertStatus(t, resp, http.StatusOK)
+	body := decodeJSON(t, resp)
+	if body["boolean"] != true || body["string"] != "Hello, world!" {
+		t.Fatalf("unexpected types body: %#v", body)
+	}
+
+	resp = api.Put("/types?status=202", map[string]any{"hello": "world"})
+	assertStatus(t, resp, http.StatusAccepted)
+	body = decodeJSON(t, resp)
+	if body["method"] != http.MethodPut || body["path"] != "/types" {
+		t.Fatalf("unexpected echo body: %#v", body)
+	}
+
+	resp = api.Get("/cached/5?private=true")
+	assertStatus(t, resp, http.StatusOK)
+	assertHeader(t, resp, "Cache-Control", "private, max-age=5")
+
+	resp = api.Get("/status/418?retry-after=3&x-retry-in=soon")
+	assertStatus(t, resp, http.StatusTeapot)
+	assertHeader(t, resp, "Retry-After", "3")
+	assertHeader(t, resp, "X-Retry-In", "soon")
+
+	resp = api.Get("/headers", "X-Test-Header: yes")
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), "X-Test-Header") {
+		t.Fatalf("headers response did not echo header: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/user-agent", "User-Agent: apibin-test")
+	assertStatus(t, resp, http.StatusOK)
+	if decodeJSON(t, resp)["user-agent"] != "apibin-test" {
+		t.Fatalf("unexpected user-agent body: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/response-headers?X-Reply=yes")
+	assertStatus(t, resp, http.StatusOK)
+	assertHeader(t, resp, "X-Reply", "yes")
+
+	resp = api.Post("/post", map[string]any{"hello": "world"})
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), `"parsed":{"hello":"world"}`) {
+		t.Fatalf("echo response missing raw body: %s", resp.Body.String())
+	}
+}
+
+func TestImagesAndContentNegotiation(t *testing.T) {
+	api := newTestAPI(t)
+
+	resp := api.Get("/images?limit=1&search=dragon")
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), "Dragonfly macro") {
+		t.Fatalf("filtered images response mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/images?cursor=abc123&format=png")
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), `"format":"png"`) {
+		t.Fatalf("cursor image response mismatch: %s", resp.Body.String())
+	}
+
+	for _, route := range []struct {
+		path        string
+		contentType string
+	}{
+		{"/images/jpeg", "image/jpeg"},
+		{"/images/webp", "image/webp"},
+		{"/images/gif", "image/gif"},
+		{"/images/png", "image/png"},
+		{"/images/heic", "image/heic"},
+	} {
+		resp = api.Get(route.path)
+		assertStatus(t, resp, http.StatusOK)
+		assertHeader(t, resp, "Content-Type", route.contentType)
+		if resp.Body.Len() == 0 {
+			t.Fatalf("%s returned empty image body", route.path)
+		}
+	}
+
+	resp = api.Get("/image", "Accept: image/webp,image/png")
+	assertStatus(t, resp, http.StatusOK)
+	assertHeader(t, resp, "Content-Type", "image/webp")
+
+	resp = api.Get("/image", "Accept: image/png;q=0")
+	assertStatus(t, resp, http.StatusNotAcceptable)
+}
+
+func TestBooksAndItemsCRUD(t *testing.T) {
+	api := newTestAPI(t)
+
+	resp := api.Get("/books")
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), "/books/sapiens") {
+		t.Fatalf("books list missing sapiens: %s", resp.Body.String())
+	}
+
+	resp = api.Put("/books/test-book", Book{Title: "Test Book", Author: "Codex"})
+	assertStatus(t, resp, http.StatusNoContent)
+
+	resp = api.Get("/books/test-book")
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), "Test Book") {
+		t.Fatalf("created book not returned: %s", resp.Body.String())
+	}
+
+	resp = api.Delete("/books/test-book")
+	assertStatus(t, resp, http.StatusNoContent)
+
+	resp = api.Get("/books/test-book")
+	assertStatus(t, resp, http.StatusNotFound)
+
+	resp = api.Get("/items")
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), "Alpha item") {
+		t.Fatalf("items list missing alpha: %s", resp.Body.String())
+	}
+
+	resp = api.Post("/items", Item{ID: "test-item", Name: "Test Item", Enabled: true})
+	assertStatus(t, resp, http.StatusOK)
+
+	resp = api.Patch("/items/test-item", map[string]any{"name": "Patched", "enabled": false, "tags": []string{"x", "y"}})
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), "Patched") {
+		t.Fatalf("patched item response mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/items/test-item")
+	assertStatus(t, resp, http.StatusOK)
+
+	resp = api.Delete("/items/test-item")
+	assertStatus(t, resp, http.StatusNoContent)
+
+	resp = api.Get("/items/test-item")
+	assertStatus(t, resp, http.StatusNotFound)
+}
+
+func TestAuthFormsUploadsAndUtilities(t *testing.T) {
+	api := newTestAPI(t)
+
+	resp := api.Post("/login", "Content-Type: application/x-www-form-urlencoded", strings.NewReader("username=alice&password=secret"))
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), "docs-token-alice") {
+		t.Fatalf("login response mismatch: %s", resp.Body.String())
+	}
+
+	var upload bytes.Buffer
+	writer := multipart.NewWriter(&upload)
+	if err := writer.WriteField("note", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	file, err := writer.CreateFormFile("file", "hello.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write([]byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	resp = api.Post("/uploads", "Content-Type: "+writer.FormDataContentType(), &upload)
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), "hello.txt") {
+		t.Fatalf("upload response mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/auth/basic")
+	assertStatus(t, resp, http.StatusUnauthorized)
+
+	basic := base64.StdEncoding.EncodeToString([]byte("alice:secret"))
+	resp = api.Get("/auth/basic", "Authorization: Basic "+basic)
+	assertStatus(t, resp, http.StatusOK)
+
+	resp = api.Get("/auth/bearer", "Authorization: Bearer token-123")
+	assertStatus(t, resp, http.StatusOK)
+
+	resp = api.Get("/auth/api-key-header", "X-API-Key: key-123")
+	assertStatus(t, resp, http.StatusOK)
+
+	resp = api.Get("/auth/api-key-query?api_key=query-key")
+	assertStatus(t, resp, http.StatusOK)
+
+	resp = api.Get("/cookies", "Cookie: a=1; b=2")
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), `"a":"1"`) {
+		t.Fatalf("cookies response mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/cookies/set?session=abc")
+	assertStatus(t, resp, http.StatusOK)
+	if got := resp.Header().Values("Set-Cookie"); len(got) != 1 || !strings.Contains(got[0], "session=abc") {
+		t.Fatalf("set-cookie headers = %#v", got)
+	}
+
+	resp = api.Get("/cookies/delete?session")
+	assertStatus(t, resp, http.StatusOK)
+	if got := resp.Header().Values("Set-Cookie"); len(got) != 1 || !strings.Contains(got[0], "Max-Age=0") {
+		t.Fatalf("delete-cookie headers = %#v", got)
+	}
+
+	resp = api.Get("/uuid")
+	assertStatus(t, resp, http.StatusOK)
+	if len(decodeJSON(t, resp)["uuid"].(string)) != 36 {
+		t.Fatalf("uuid response mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/ip", "X-Forwarded-For: 203.0.113.1")
+	assertStatus(t, resp, http.StatusOK)
+	if decodeJSON(t, resp)["origin"] != "203.0.113.1" {
+		t.Fatalf("ip response mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/html")
+	assertStatus(t, resp, http.StatusOK)
+	assertHeader(t, resp, "Content-Type", "text/html; charset=utf-8")
+
+	resp = api.Get("/xml")
+	assertStatus(t, resp, http.StatusOK)
+	assertHeader(t, resp, "Content-Type", "application/xml")
+
+	resp = api.Get("/base64/encode/hello")
+	assertStatus(t, resp, http.StatusOK)
+	encoded := decodeJSON(t, resp)["encoded"].(string)
+
+	resp = api.Get("/base64/decode/" + encoded)
+	assertStatus(t, resp, http.StatusOK)
+	if decodeJSON(t, resp)["decoded"] != "hello" {
+		t.Fatalf("base64 decode response mismatch: %s", resp.Body.String())
+	}
+}
+
+func TestReliabilityRedirectsBinaryAndContentFixtures(t *testing.T) {
+	api := newTestAPI(t)
+
+	resp := api.Get("/flaky?key=test&failures=1")
+	assertStatus(t, resp, http.StatusServiceUnavailable)
+	resp = api.Get("/flaky?key=test&failures=1")
+	assertStatus(t, resp, http.StatusOK)
+
+	resp = api.Get("/slow?delay=0s")
+	assertStatus(t, resp, http.StatusOK)
+
+	resp = api.Get("/redirect/2")
+	assertStatus(t, resp, http.StatusFound)
+	assertHeader(t, resp, "Location", "/relative-redirect/1")
+
+	resp = api.Get("/absolute-redirect/1", "Host: api.example", "X-Forwarded-Proto: https")
+	assertStatus(t, resp, http.StatusFound)
+	assertHeader(t, resp, "Location", "https://api.example/get")
+
+	resp = api.Get("/redirect-to?url=https%3A%2F%2Fexample.com%2Fnext&status_code=307")
+	assertStatus(t, resp, http.StatusTemporaryRedirect)
+	assertHeader(t, resp, "Location", "https://example.com/next")
+
+	resp = api.Get("/bytes/16?seed=1")
+	assertStatus(t, resp, http.StatusOK)
+	assertHeader(t, resp, "Content-Type", "application/octet-stream")
+	if resp.Body.Len() != 16 {
+		t.Fatalf("bytes length = %d, want 16", resp.Body.Len())
+	}
+
+	resp = api.Get("/stream-bytes/10?chunk_size=3&seed=1")
+	assertStatus(t, resp, http.StatusOK)
+	if resp.Body.Len() != 10 {
+		t.Fatalf("stream bytes length = %d, want 10", resp.Body.Len())
+	}
+
+	resp = api.Get("/range/100", "Range: bytes=0-9")
+	assertStatus(t, resp, http.StatusPartialContent)
+	if resp.Body.Len() != 10 {
+		t.Fatalf("range length = %d, want 10", resp.Body.Len())
+	}
+
+	resp = api.Get("/range/100", "Range: bytes=-10")
+	assertStatus(t, resp, http.StatusRequestedRangeNotSatisfiable)
+
+	resp = api.Get("/drip?numbytes=3&duration=0s")
+	assertStatus(t, resp, http.StatusOK)
+	if resp.Body.String() != "***" {
+		t.Fatalf("drip body = %q, want ***", resp.Body.String())
+	}
+
+	for _, route := range []struct {
+		path     string
+		encoding string
+		read     func([]byte) ([]byte, error)
+	}{
+		{"/gzip", "gzip", gunzip},
+		{"/deflate", "deflate", inflate},
+		{"/brotli", "br", unbrotli},
+	} {
+		resp = api.Get(route.path)
+		assertStatus(t, resp, http.StatusOK)
+		assertHeader(t, resp, "Content-Encoding", route.encoding)
+		decoded, err := route.read(resp.Body.Bytes())
+		if err != nil {
+			t.Fatalf("%s decode failed: %v", route.path, err)
+		}
+		if !strings.Contains(string(decoded), `"compressed":true`) {
+			t.Fatalf("%s decoded body mismatch: %s", route.path, decoded)
+		}
+	}
+
+	resp = api.Get("/problem")
+	assertStatus(t, resp, http.StatusBadRequest)
+	assertHeader(t, resp, "Content-Type", "application/problem+json")
+
+	for _, route := range []struct {
+		path        string
+		contentType string
+	}{
+		{"/formats/json", "application/json"},
+		{"/formats/yaml", "application/yaml"},
+		{"/formats/cbor", "application/cbor"},
+		{"/formats/vendor-json", "application/vnd.api+json"},
+	} {
+		resp = api.Get(route.path)
+		assertStatus(t, resp, http.StatusOK)
+		assertHeader(t, resp, "Content-Type", route.contentType)
+	}
+}
+
+func TestStreamingEndpoints(t *testing.T) {
+	api := newTestAPI(t)
+
+	resp := api.Get("/sse/metrics?count=1", "Accept: text/event-stream")
+	assertStatus(t, resp, http.StatusOK)
+	assertHeader(t, resp, "Content-Type", "text/event-stream")
+	if !strings.Contains(resp.Body.String(), "event: metrics") {
+		t.Fatalf("metrics SSE response mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/events?count=1", "Accept: text/event-stream")
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), "event: event") {
+		t.Fatalf("events SSE response mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/logs?count=1")
+	assertStatus(t, resp, http.StatusOK)
+	assertHeader(t, resp, "Content-Type", "application/x-ndjson")
+	if !strings.Contains(resp.Body.String(), `"type":"login"`) {
+		t.Fatalf("logs response mismatch: %s", resp.Body.String())
+	}
+}
+
+func TestErrorPathsAndFixtureVariants(t *testing.T) {
+	api := newTestAPI(t)
+
+	for _, route := range []struct {
+		method string
+		path   string
+		args   []any
+		status int
+	}{
+		{http.MethodPost, "/login", []any{"Content-Type: application/x-www-form-urlencoded", strings.NewReader("%")}, http.StatusBadRequest},
+		{http.MethodPost, "/uploads", []any{"Content-Type: multipart/form-data", strings.NewReader("bad")}, http.StatusBadRequest},
+		{http.MethodGet, "/auth/bearer", nil, http.StatusUnauthorized},
+		{http.MethodGet, "/auth/api-key-header", nil, http.StatusUnauthorized},
+		{http.MethodGet, "/auth/api-key-query", nil, http.StatusUnauthorized},
+		{http.MethodGet, "/slow?delay=bad", nil, http.StatusBadRequest},
+		{http.MethodGet, "/slow?delay=11s", nil, http.StatusBadRequest},
+		{http.MethodGet, "/drip?duration=bad", nil, http.StatusBadRequest},
+		{http.MethodGet, "/drip?duration=31s", nil, http.StatusBadRequest},
+		{http.MethodGet, "/drip?delay=bad", nil, http.StatusBadRequest},
+		{http.MethodGet, "/drip?delay=11s", nil, http.StatusBadRequest},
+		{http.MethodGet, "/base64/decode/not-valid!", nil, http.StatusBadRequest},
+		{http.MethodGet, "/formats/bad", nil, http.StatusUnprocessableEntity},
+		{http.MethodGet, "/images/bad", nil, http.StatusUnprocessableEntity},
+	} {
+		resp := api.Do(route.method, route.path, route.args...)
+		assertStatus(t, resp, route.status)
+	}
+
+	resp := api.Get("/cache")
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), `"cache":"fresh"`) {
+		t.Fatalf("cache body mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/etag/docs", `If-Match: "other"`)
+	assertStatus(t, resp, http.StatusPreconditionFailed)
+
+	resp = api.Get("/images?cursor=def456&per_page=1")
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), `"format":"heic"`) {
+		t.Fatalf("last image page mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Get("/images?cursor=unknown")
+	assertStatus(t, resp, http.StatusOK)
+	if strings.TrimSpace(resp.Body.String()) != "[]" {
+		t.Fatalf("unknown image cursor body = %s, want []", resp.Body.String())
+	}
+
+	resp = api.Get("/anything/some-path")
+	assertStatus(t, resp, http.StatusOK)
+	if decodeJSON(t, resp)["path"] != "/anything/some-path" {
+		t.Fatalf("anything path mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Do(http.MethodHead, "/head")
+	assertStatus(t, resp, http.StatusOK)
+
+	resp = api.Do(http.MethodOptions, "/options")
+	assertStatus(t, resp, http.StatusOK)
+
+	resp = api.Get("/bytes/4")
+	assertStatus(t, resp, http.StatusOK)
+	if resp.Body.Len() != 4 {
+		t.Fatalf("unseeded bytes length = %d, want 4", resp.Body.Len())
+	}
+
+	resp = api.Post("/items", Item{Name: "Generated ID", Enabled: true})
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), `"id":"item-`) {
+		t.Fatalf("generated item ID response mismatch: %s", resp.Body.String())
+	}
+
+	resp = api.Patch("/items/alpha", map[string]any{"tags": []any{1, "kept"}})
+	assertStatus(t, resp, http.StatusOK)
+	if !strings.Contains(resp.Body.String(), `"tags":["kept"]`) {
+		t.Fatalf("patch tags response mismatch: %s", resp.Body.String())
+	}
+}
+
+func TestOpenAPIAndHelperCoverage(t *testing.T) {
+	api := newTestAPI(t)
+	paths := api.OpenAPI().Paths
+
+	if paths["/status/{code}"].Get.Responses["418"] == nil {
+		t.Fatal("OpenAPI should document dynamic /status/{code} responses")
+	}
+	if paths["/redirect-to"].Get.Responses["307"] == nil || paths["/redirect-to"].Get.Responses["399"] == nil {
+		t.Fatal("OpenAPI should document redirect-to status range")
+	}
+	if paths["/redirect/{n}"].Get.Responses["302"].Headers["Location"] == nil {
+		t.Fatal("OpenAPI should document redirect Location header")
+	}
+
+	for _, tt := range []struct {
+		spec   string
+		length int
+		start  int
+		end    int
+		ok     bool
+	}{
+		{"0-9", 100, 0, 10, true},
+		{"10-", 100, 10, 100, true},
+		{"-10", 100, 0, 0, false},
+		{"200-201", 100, 0, 0, false},
+	} {
+		start, end, ok := parseByteRange(tt.spec, tt.length)
+		if start != tt.start || end != tt.end || ok != tt.ok {
+			t.Fatalf("parseByteRange(%q, %d) = %d, %d, %v; want %d, %d, %v", tt.spec, tt.length, start, end, ok, tt.start, tt.end, tt.ok)
+		}
+	}
+
+	for _, tt := range []struct {
+		header string
+		user   string
+		pass   string
+		ok     bool
+	}{
+		{"", "", "", false},
+		{"Basic bad", "", "", false},
+		{"Basic " + base64.StdEncoding.EncodeToString([]byte("u:p")), "u", "p", true},
+	} {
+		user, pass, ok := parseBasic(tt.header)
+		if user != tt.user || pass != tt.pass || ok != tt.ok {
+			t.Fatalf("parseBasic(%q) = %q, %q, %v; want %q, %q, %v", tt.header, user, pass, ok, tt.user, tt.pass, tt.ok)
+		}
+	}
+
+	if string(makeBytes(8, 42)) != string(makeBytes(8, 42)) {
+		t.Fatal("seeded makeBytes should be deterministic")
+	}
+}
+
+func TestAcceptImageFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		accept string
+		format string
+		ok     bool
+	}{
+		{"empty defaults to png", "", "png", true},
+		{"client order breaks ties", "image/webp,image/png", "webp", true},
+		{"q value wins", "image/png;q=0.4,image/webp;q=0.9", "webp", true},
+		{"q zero is rejected", "image/png;q=0", "", false},
+		{"specific beats wildcard", "image/*;q=0.8,image/heic;q=0.9", "heic", true},
+		{"unsupported is rejected", "application/json", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format, ok := acceptImageFormat(tt.accept)
+			if format != tt.format || ok != tt.ok {
+				t.Fatalf("acceptImageFormat(%q) = %q, %v; want %q, %v", tt.accept, format, ok, tt.format, tt.ok)
+			}
+		})
+	}
+}
+
+func TestContentEncodingMiddleware(t *testing.T) {
+	payload := strings.Repeat("hello ", 400)
+	handler := ContentEncoding(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte(payload))
+	}))
+
+	for _, tt := range []struct {
+		acceptEncoding  string
+		contentEncoding string
+		read            func([]byte) ([]byte, error)
+	}{
+		{"gzip", "gzip", gunzip},
+		{"br, gzip", "br", unbrotli},
+	} {
+		req, _ := http.NewRequest(http.MethodGet, "/large", nil)
+		req.Header.Set("Accept-Encoding", tt.acceptEncoding)
+		resp := &testResponseWriter{header: http.Header{}}
+		handler.ServeHTTP(resp, req)
+
+		if got := resp.header.Get("Content-Encoding"); got != tt.contentEncoding {
+			t.Fatalf("Content-Encoding = %q, want %q", got, tt.contentEncoding)
+		}
+		decoded, err := tt.read(resp.body.Bytes())
+		if err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if string(decoded) != payload {
+			t.Fatal("decoded payload mismatch")
+		}
+	}
+}
+
+func TestContentEncodingMiddlewareStatusAndSmallBody(t *testing.T) {
+	handler := ContentEncoding(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("small"))
+	}))
+
+	req, _ := http.NewRequest(http.MethodGet, "/small", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	resp := &testResponseWriter{header: http.Header{}}
+	handler.ServeHTTP(resp, req)
+
+	if resp.status != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", resp.status, http.StatusCreated)
+	}
+	if got := resp.header.Get("Content-Encoding"); got != "" {
+		t.Fatalf("small body Content-Encoding = %q, want empty", got)
+	}
+	if resp.body.String() != "small" {
+		t.Fatalf("small body = %q", resp.body.String())
+	}
+}
+
+type testResponseWriter struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+func (w *testResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *testResponseWriter) Write(data []byte) (int, error) {
+	return w.body.Write(data)
+}
+
+func (w *testResponseWriter) WriteHeader(statusCode int) {
+	w.status = statusCode
+}
+
+func gunzip(data []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return io.ReadAll(r)
+}
+
+func inflate(data []byte) ([]byte, error) {
+	r, err := zlib.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return io.ReadAll(r)
+}
+
+func unbrotli(data []byte) ([]byte, error) {
+	return io.ReadAll(brotli.NewReader(bytes.NewReader(data)))
+}
+
+func TestStatusTextFallback(t *testing.T) {
+	if got := statusText(299); got != "Status 299" {
+		t.Fatalf("statusText fallback = %q", got)
+	}
+}

--- a/api_test.go
+++ b/api_test.go
@@ -586,8 +586,23 @@ func TestOpenAPIAndHelperCoverage(t *testing.T) {
 		}
 	}
 
-	if string(makeBytes(8, 42)) != string(makeBytes(8, 42)) {
+	left, err := makeBytes(8, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := makeBytes(8, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(left) != string(right) {
 		t.Fatal("seeded makeBytes should be deterministic")
+	}
+
+	sim := newMetricSimulator()
+	first := sim.next().Region
+	second := sim.next().Region
+	if first == second {
+		t.Fatalf("metric simulator should rotate regions, got %q twice", first)
 	}
 }
 

--- a/books.go
+++ b/books.go
@@ -171,7 +171,7 @@ func (s *APIServer) RegisterGetBook(api huma.API) {
 
 		resp := &GetBookResponse{
 			CacheControl: "max-age:0",
-			ETag:         b.Version(),
+			ETag:         quoteETag(b.Version()),
 			LastModified: b.modified,
 			Vary:         "Accept, Accept-Encoding, Origin",
 			Body:         b,

--- a/compress.go
+++ b/compress.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/andybalholm/brotli"
@@ -20,6 +21,7 @@ const brotliEncoding = "br"
 
 var supportedEncodings []string = []string{brotliEncoding, gzipEncoding}
 var compressDenyList []string = []string{".gif", ".png", ".jpg", ".jpeg", ".zip", ".gz", ".bz2"}
+var compressDenyPaths []string = []string{"/sse/metrics"}
 
 type contentEncodingWriter struct {
 	http.ResponseWriter
@@ -130,6 +132,14 @@ func ContentEncoding(next http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, deny := range compressDenyPaths {
+			if strings.HasPrefix(r.URL.Path, deny) {
+				// This is a path we should not try to compress.
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
 		if ext := path.Ext(r.URL.Path); ext != "" {
 			for _, deny := range compressDenyList {
 				if ext == deny {

--- a/compress.go
+++ b/compress.go
@@ -21,7 +21,7 @@ const brotliEncoding = "br"
 
 var supportedEncodings []string = []string{brotliEncoding, gzipEncoding}
 var compressDenyList []string = []string{".gif", ".png", ".jpg", ".jpeg", ".zip", ".gz", ".bz2"}
-var compressDenyPaths []string = []string{"/sse/metrics"}
+var compressDenyPaths []string = []string{"/sse/metrics", "/events", "/logs", "/stream-bytes", "/drip"}
 
 type contentEncodingWriter struct {
 	http.ResponseWriter

--- a/echo.go
+++ b/echo.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -48,6 +49,10 @@ func genETagBytes(b []byte) string {
 	sum := make([]byte, 8)
 	binary.BigEndian.PutUint64(sum, hash)
 	return base64.RawURLEncoding.EncodeToString(sum)
+}
+
+func quoteETag(tag string) string {
+	return strconv.Quote(tag)
 }
 
 type EchoResponse struct {
@@ -119,7 +124,7 @@ func (s *APIServer) echoHandler(ctx context.Context, input *struct {
 	resp.CacheControl = "no-store"
 	resp.Vary = "*"
 	resp.LastModified = lastModified
-	resp.ETag = etag
+	resp.ETag = quoteETag(etag)
 
 	return resp, nil
 }

--- a/example.go
+++ b/example.go
@@ -131,7 +131,7 @@ func (s *APIServer) RegisterExample(api huma.API) {
 		Tags:        []string{"Example"},
 	}, func(ctx context.Context, i *struct{}) (*ExampleResponse, error) {
 		return &ExampleResponse{
-			ETag: exampleEtag,
+			ETag: quoteETag(exampleEtag),
 			Body: example,
 		}, nil
 	})

--- a/fixtures.go
+++ b/fixtures.go
@@ -1,0 +1,1113 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"math"
+	mathrand "math/rand"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/andybalholm/brotli"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/fxamacker/cbor/v2"
+	"gopkg.in/yaml.v2"
+)
+
+type TokenResponse struct {
+	Body struct {
+		Token     string `json:"token"`
+		TokenType string `json:"token_type"`
+		User      string `json:"user"`
+	}
+}
+
+func (s *APIServer) RegisterLogin(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "post-login",
+		Method:      http.MethodPost,
+		Path:        "/login",
+		Summary:     "Mock form login",
+		Description: "Accepts an application/x-www-form-urlencoded username and password and returns a mock bearer token.",
+		Tags:        []string{"Auth"},
+	}, func(ctx context.Context, input *struct {
+		RawBody []byte `contentType:"application/x-www-form-urlencoded"`
+	}) (*TokenResponse, error) {
+		form, err := url.ParseQuery(string(input.RawBody))
+		if err != nil {
+			return nil, huma.Error400BadRequest("invalid form body")
+		}
+		user := form.Get("username")
+		if user == "" {
+			user = "anonymous"
+		}
+		resp := &TokenResponse{}
+		resp.Body.Token = "docs-token-" + user
+		resp.Body.TokenType = "Bearer"
+		resp.Body.User = user
+		return resp, nil
+	})
+}
+
+type UploadFile struct {
+	Field       string `json:"field"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type,omitempty"`
+	Size        int64  `json:"size"`
+}
+
+type UploadResponse struct {
+	Body struct {
+		Fields map[string][]string `json:"fields"`
+		Files  []UploadFile        `json:"files"`
+	}
+}
+
+func (s *APIServer) RegisterUploads(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "post-upload",
+		Method:      http.MethodPost,
+		Path:        "/uploads",
+		Summary:     "Echo multipart upload metadata",
+		Tags:        []string{"Uploads"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+		RawBody []byte `contentType:"multipart/form-data"`
+	}) (*UploadResponse, error) {
+		_, params, err := mime.ParseMediaType(input.ctx.Header("Content-Type"))
+		if err != nil {
+			return nil, huma.Error400BadRequest("invalid multipart content type")
+		}
+		boundary := params["boundary"]
+		if boundary == "" {
+			return nil, huma.Error400BadRequest("missing multipart boundary")
+		}
+		form, err := multipart.NewReader(bytes.NewReader(input.RawBody), boundary).ReadForm(32 << 20)
+		if err != nil {
+			return nil, huma.Error400BadRequest("invalid multipart body")
+		}
+		resp := &UploadResponse{}
+		resp.Body.Fields = form.Value
+		for field, files := range form.File {
+			for _, fh := range files {
+				size := fh.Size
+				if size == 0 {
+					if f, err := fh.Open(); err == nil {
+						n, _ := io.Copy(io.Discard, f)
+						f.Close()
+						size = n
+					}
+				}
+				resp.Body.Files = append(resp.Body.Files, UploadFile{
+					Field:       field,
+					Filename:    fh.Filename,
+					ContentType: fh.Header.Get("Content-Type"),
+					Size:        size,
+				})
+			}
+		}
+		return resp, nil
+	})
+}
+
+type AuthResponse struct {
+	Body struct {
+		Authenticated bool   `json:"authenticated"`
+		Scheme        string `json:"scheme"`
+		Subject       string `json:"subject,omitempty"`
+	}
+}
+
+func addAuthSchemes(api huma.API) {
+	o := api.OpenAPI()
+	if o.Components.SecuritySchemes == nil {
+		o.Components.SecuritySchemes = map[string]*huma.SecurityScheme{}
+	}
+	o.Components.SecuritySchemes["basicAuth"] = &huma.SecurityScheme{Type: "http", Scheme: "basic"}
+	o.Components.SecuritySchemes["bearerAuth"] = &huma.SecurityScheme{Type: "http", Scheme: "bearer", BearerFormat: "opaque"}
+	o.Components.SecuritySchemes["apiKeyHeader"] = &huma.SecurityScheme{Type: "apiKey", In: "header", Name: "X-API-Key"}
+	o.Components.SecuritySchemes["apiKeyQuery"] = &huma.SecurityScheme{Type: "apiKey", In: "query", Name: "api_key"}
+}
+
+func authOK(scheme, subject string) *AuthResponse {
+	resp := &AuthResponse{}
+	resp.Body.Authenticated = true
+	resp.Body.Scheme = scheme
+	resp.Body.Subject = subject
+	return resp
+}
+
+func (s *APIServer) RegisterAuthBasic(api huma.API) {
+	addAuthSchemes(api)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-auth-basic",
+		Method:      http.MethodGet,
+		Path:        "/auth/basic",
+		Summary:     "Require HTTP Basic auth",
+		Tags:        []string{"Auth"},
+		Security:    []map[string][]string{{"basicAuth": {}}},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*AuthResponse, error) {
+		user, pass, ok := parseBasic(input.ctx.Header("Authorization"))
+		if !ok || user == "" || pass == "" {
+			return nil, huma.Error401Unauthorized("missing or invalid Basic auth")
+		}
+		return authOK("basic", user), nil
+	})
+}
+
+func (s *APIServer) RegisterAuthBearer(api huma.API) {
+	addAuthSchemes(api)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-auth-bearer",
+		Method:      http.MethodGet,
+		Path:        "/auth/bearer",
+		Summary:     "Require bearer token auth",
+		Tags:        []string{"Auth"},
+		Security:    []map[string][]string{{"bearerAuth": {}}},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*AuthResponse, error) {
+		token := strings.TrimPrefix(input.ctx.Header("Authorization"), "Bearer ")
+		if token == "" {
+			return nil, huma.Error401Unauthorized("missing bearer token")
+		}
+		return authOK("bearer", token), nil
+	})
+}
+
+func (s *APIServer) RegisterAuthAPIKeyHeader(api huma.API) {
+	addAuthSchemes(api)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-auth-api-key-header",
+		Method:      http.MethodGet,
+		Path:        "/auth/api-key-header",
+		Summary:     "Require an API key header",
+		Tags:        []string{"Auth"},
+		Security:    []map[string][]string{{"apiKeyHeader": {}}},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*AuthResponse, error) {
+		key := input.ctx.Header("X-API-Key")
+		if key == "" {
+			return nil, huma.Error401Unauthorized("missing X-API-Key")
+		}
+		return authOK("api-key-header", key), nil
+	})
+}
+
+func (s *APIServer) RegisterAuthAPIKeyQuery(api huma.API) {
+	addAuthSchemes(api)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-auth-api-key-query",
+		Method:      http.MethodGet,
+		Path:        "/auth/api-key-query",
+		Summary:     "Require an API key query parameter",
+		Tags:        []string{"Auth"},
+		Security:    []map[string][]string{{"apiKeyQuery": {}}},
+	}, func(ctx context.Context, input *struct {
+		APIKey string `query:"api_key" doc:"API key"`
+	}) (*AuthResponse, error) {
+		if input.APIKey == "" {
+			return nil, huma.Error401Unauthorized("missing api_key")
+		}
+		return authOK("api-key-query", input.APIKey), nil
+	})
+}
+
+func parseBasic(header string) (string, string, bool) {
+	if !strings.HasPrefix(header, "Basic ") {
+		return "", "", false
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(header, "Basic "))
+	if err != nil {
+		return "", "", false
+	}
+	user, pass, ok := strings.Cut(string(decoded), ":")
+	return user, pass, ok
+}
+
+type Item struct {
+	ID      string    `json:"id"`
+	Name    string    `json:"name"`
+	Enabled bool      `json:"enabled"`
+	Tags    []string  `json:"tags,omitempty"`
+	Updated time.Time `json:"updated"`
+}
+
+type ItemsResponse struct {
+	Body []Item
+}
+
+type ItemResponse struct {
+	Body Item
+}
+
+var itemsMu = sync.RWMutex{}
+var items = map[string]Item{}
+var itemOrder = []string{}
+
+func resetItems() {
+	itemsMu.Lock()
+	defer itemsMu.Unlock()
+	now := time.Now().UTC().Truncate(time.Second)
+	items = map[string]Item{
+		"alpha": {ID: "alpha", Name: "Alpha item", Enabled: true, Tags: []string{"docs", "example"}, Updated: now},
+		"beta":  {ID: "beta", Name: "Beta item", Enabled: false, Tags: []string{"demo"}, Updated: now},
+	}
+	itemOrder = []string{"alpha", "beta"}
+}
+
+func init() {
+	resetItems()
+	go func() {
+		for {
+			time.Sleep(10 * time.Minute)
+			resetItems()
+		}
+	}()
+}
+
+func (s *APIServer) RegisterListItems(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "list-items",
+		Method:      http.MethodGet,
+		Path:        "/items",
+		Summary:     "List sample items",
+		Tags:        []string{"Items"},
+	}, func(ctx context.Context, input *struct{}) (*ItemsResponse, error) {
+		itemsMu.RLock()
+		defer itemsMu.RUnlock()
+		body := make([]Item, 0, len(itemOrder))
+		for _, id := range itemOrder {
+			body = append(body, items[id])
+		}
+		return &ItemsResponse{Body: body}, nil
+	})
+}
+
+func (s *APIServer) RegisterGetItem(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-item",
+		Method:      http.MethodGet,
+		Path:        "/items/{item-id}",
+		Summary:     "Get a sample item",
+		Tags:        []string{"Items"},
+	}, func(ctx context.Context, input *struct {
+		ID string `path:"item-id"`
+	}) (*ItemResponse, error) {
+		itemsMu.RLock()
+		defer itemsMu.RUnlock()
+		item, ok := items[input.ID]
+		if !ok {
+			return nil, huma.Error404NotFound(input.ID + " not found")
+		}
+		return &ItemResponse{Body: item}, nil
+	})
+}
+
+func (s *APIServer) RegisterPostItem(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "create-item",
+		Method:      http.MethodPost,
+		Path:        "/items",
+		Summary:     "Create a sample item",
+		Tags:        []string{"Items"},
+	}, func(ctx context.Context, input *struct {
+		Body Item
+	}) (*ItemResponse, error) {
+		itemsMu.Lock()
+		defer itemsMu.Unlock()
+		item := input.Body
+		if item.ID == "" {
+			item.ID = fmt.Sprintf("item-%d", time.Now().UnixNano())
+		}
+		if _, ok := items[item.ID]; !ok {
+			itemOrder = append(itemOrder, item.ID)
+		}
+		item.Updated = time.Now().UTC().Truncate(time.Second)
+		items[item.ID] = item
+		return &ItemResponse{Body: item}, nil
+	})
+}
+
+func (s *APIServer) RegisterPatchItem(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "patch-item",
+		Method:      http.MethodPatch,
+		Path:        "/items/{item-id}",
+		Summary:     "Patch a sample item",
+		Tags:        []string{"Items"},
+	}, func(ctx context.Context, input *struct {
+		ID   string `path:"item-id"`
+		Body map[string]any
+	}) (*ItemResponse, error) {
+		itemsMu.Lock()
+		defer itemsMu.Unlock()
+		item, ok := items[input.ID]
+		if !ok {
+			return nil, huma.Error404NotFound(input.ID + " not found")
+		}
+		if name, ok := input.Body["name"].(string); ok {
+			item.Name = name
+		}
+		if enabled, ok := input.Body["enabled"].(bool); ok {
+			item.Enabled = enabled
+		}
+		if tags, ok := input.Body["tags"].([]any); ok {
+			item.Tags = item.Tags[:0]
+			for _, tag := range tags {
+				if s, ok := tag.(string); ok {
+					item.Tags = append(item.Tags, s)
+				}
+			}
+		}
+		item.Updated = time.Now().UTC().Truncate(time.Second)
+		items[input.ID] = item
+		return &ItemResponse{Body: item}, nil
+	})
+}
+
+func (s *APIServer) RegisterDeleteItem(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "delete-item",
+		Method:      http.MethodDelete,
+		Path:        "/items/{item-id}",
+		Summary:     "Delete a sample item",
+		Tags:        []string{"Items"},
+	}, func(ctx context.Context, input *struct {
+		ID string `path:"item-id"`
+	}) (*struct{}, error) {
+		itemsMu.Lock()
+		defer itemsMu.Unlock()
+		delete(items, input.ID)
+		for i, id := range itemOrder {
+			if id == input.ID {
+				itemOrder = append(itemOrder[:i], itemOrder[i+1:]...)
+				break
+			}
+		}
+		return nil, nil
+	})
+}
+
+var flakyMu sync.Mutex
+var flakyCounts = map[string]int{}
+
+func (s *APIServer) RegisterFlaky(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-flaky",
+		Method:      http.MethodGet,
+		Path:        "/flaky",
+		Summary:     "Fail a configurable number of times, then succeed",
+		Tags:        []string{"Reliability"},
+	}, func(ctx context.Context, input *struct {
+		Failures int    `query:"failures" default:"2" minimum:"0" maximum:"20"`
+		Key      string `query:"key" default:"default"`
+	}) (*struct {
+		Status int
+		Body   map[string]any
+	}, error) {
+		flakyMu.Lock()
+		defer flakyMu.Unlock()
+		key := input.Key
+		if key == "" {
+			key = "default"
+		}
+		attempt := flakyCounts[key] + 1
+		flakyCounts[key] = attempt
+		if attempt <= input.Failures {
+			return &struct {
+				Status int
+				Body   map[string]any
+			}{Status: http.StatusServiceUnavailable, Body: map[string]any{
+				"attempt":  attempt,
+				"failures": input.Failures,
+				"key":      key,
+				"ok":       false,
+			}}, nil
+		}
+		return &struct {
+			Status int
+			Body   map[string]any
+		}{Status: http.StatusOK, Body: map[string]any{
+			"attempt":  attempt,
+			"failures": input.Failures,
+			"key":      key,
+			"ok":       true,
+		}}, nil
+	})
+}
+
+func (s *APIServer) RegisterSlow(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-slow",
+		Method:      http.MethodGet,
+		Path:        "/slow",
+		Summary:     "Delay before responding",
+		Tags:        []string{"Reliability"},
+	}, func(ctx context.Context, input *struct {
+		Delay string `query:"delay" default:"1s" doc:"Delay duration, for example 500ms or 2s"`
+	}) (*struct {
+		Body map[string]any
+	}, error) {
+		delay, err := time.ParseDuration(input.Delay)
+		if err != nil {
+			return nil, huma.Error400BadRequest("invalid delay")
+		}
+		if delay < 0 || delay > 10*time.Second {
+			return nil, huma.Error400BadRequest("delay must be between 0s and 10s")
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+		return &struct {
+			Body map[string]any
+		}{Body: map[string]any{"delay": delay.String(), "ok": true}}, nil
+	})
+}
+
+func (s *APIServer) RegisterRequestFixtures(api huma.API) {
+	for _, route := range []struct {
+		Method string
+		Path   string
+		ID     string
+	}{
+		{http.MethodGet, "/anything", "get-anything"},
+		{http.MethodGet, "/anything/{path}", "get-anything-path"},
+		{http.MethodGet, "/get", "get-method"},
+		{http.MethodPost, "/post", "post-method"},
+		{http.MethodPut, "/put", "put-method"},
+		{http.MethodPatch, "/patch", "patch-method"},
+		{http.MethodDelete, "/delete", "delete-method"},
+		{http.MethodHead, "/head", "head-method"},
+		{http.MethodOptions, "/options", "options-method"},
+	} {
+		huma.Register(api, huma.Operation{
+			OperationID: route.ID,
+			Method:      route.Method,
+			Path:        route.Path,
+			Summary:     "Echo request data",
+			Tags:        []string{"Inspection"},
+		}, s.echoHandler)
+	}
+}
+
+func (s *APIServer) RegisterHeaders(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-headers",
+		Method:      http.MethodGet,
+		Path:        "/headers",
+		Summary:     "Return request headers",
+		Tags:        []string{"Inspection"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*struct {
+		Body map[string]map[string]string
+	}, error) {
+		headers := map[string]string{}
+		input.ctx.EachHeader(func(name, value string) {
+			headers[name] = value
+		})
+		return &struct {
+			Body map[string]map[string]string
+		}{Body: map[string]map[string]string{"headers": headers}}, nil
+	})
+}
+
+func (s *APIServer) RegisterUserAgent(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-user-agent",
+		Method:      http.MethodGet,
+		Path:        "/user-agent",
+		Summary:     "Return the User-Agent header",
+		Tags:        []string{"Inspection"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*struct {
+		Body map[string]string
+	}, error) {
+		return &struct {
+			Body map[string]string
+		}{Body: map[string]string{"user-agent": input.ctx.Header("User-Agent")}}, nil
+	})
+}
+
+func (s *APIServer) RegisterResponseHeaders(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-response-headers",
+		Method:      http.MethodGet,
+		Path:        "/response-headers",
+		Summary:     "Set response headers from query parameters",
+		Tags:        []string{"Inspection"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*struct {
+		Body map[string]string
+	}, error) {
+		headers := map[string]string{}
+		values, _ := url.ParseQuery(input.ctx.URL().RawQuery)
+		for name, v := range values {
+			value := v[len(v)-1]
+			input.ctx.SetHeader(name, value)
+			headers[name] = value
+		}
+		return &struct {
+			Body map[string]string
+		}{Body: headers}, nil
+	})
+}
+
+func (s *APIServer) RegisterRedirects(api huma.API) {
+	for _, route := range []struct {
+		Path string
+		ID   string
+		Abs  bool
+	}{
+		{"/redirect/{n}", "get-redirect", false},
+		{"/relative-redirect/{n}", "get-relative-redirect", false},
+		{"/absolute-redirect/{n}", "get-absolute-redirect", true},
+	} {
+		abs := route.Abs
+		huma.Register(api, huma.Operation{
+			OperationID: route.ID,
+			Method:      http.MethodGet,
+			Path:        route.Path,
+			Summary:     "Redirect a configurable number of times",
+			Tags:        []string{"Redirects"},
+		}, func(ctx context.Context, input *struct {
+			RequestInfo
+			N int `path:"n" minimum:"1" maximum:"20"`
+		}) (*struct{ Status int }, error) {
+			n := input.N - 1
+			next := "/get"
+			if n > 0 {
+				prefix := "/relative-redirect"
+				if abs {
+					prefix = "/absolute-redirect"
+				}
+				next = fmt.Sprintf("%s/%d", prefix, n)
+			}
+			if abs {
+				next = schemeHost(input.ctx) + next
+			}
+			input.ctx.SetHeader("Location", next)
+			return &struct{ Status int }{Status: http.StatusFound}, nil
+		})
+	}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-redirect-to",
+		Method:      http.MethodGet,
+		Path:        "/redirect-to",
+		Summary:     "Redirect to a supplied URL",
+		Tags:        []string{"Redirects"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+		URL        string `query:"url" required:"true"`
+		StatusCode int    `query:"status_code" default:"302" minimum:"300" maximum:"399"`
+	}) (*struct{ Status int }, error) {
+		input.ctx.SetHeader("Location", input.URL)
+		return &struct{ Status int }{Status: input.StatusCode}, nil
+	})
+}
+
+func schemeHost(ctx huma.Context) string {
+	scheme := "http"
+	if proto := ctx.Header("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	}
+	return scheme + "://" + ctx.Host()
+}
+
+func (s *APIServer) RegisterETagFixture(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-etag",
+		Method:      http.MethodGet,
+		Path:        "/etag/{etag}",
+		Summary:     "Exercise ETag conditional headers",
+		Tags:        []string{"Caching"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+		ETag string `path:"etag"`
+	}) (*struct{}, error) {
+		etag := `"` + input.ETag + `"`
+		input.ctx.SetHeader("ETag", etag)
+		if input.ctx.Header("If-None-Match") == etag {
+			input.ctx.SetStatus(http.StatusNotModified)
+			return nil, nil
+		}
+		if match := input.ctx.Header("If-Match"); match != "" && match != etag {
+			input.ctx.SetStatus(http.StatusPreconditionFailed)
+			return nil, nil
+		}
+		input.ctx.SetHeader("Content-Type", "application/json")
+		_ = json.NewEncoder(input.ctx.BodyWriter()).Encode(map[string]string{"etag": input.ETag})
+		return nil, nil
+	})
+}
+
+func (s *APIServer) RegisterCacheFixture(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-cache",
+		Method:      http.MethodGet,
+		Path:        "/cache",
+		Summary:     "Return 304 when conditional request headers are present",
+		Tags:        []string{"Caching"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*struct{}, error) {
+		lastModified := time.Date(2022, 2, 1, 12, 34, 56, 0, time.UTC)
+		etag := `"docs-cache"`
+		input.ctx.SetHeader("ETag", etag)
+		input.ctx.SetHeader("Last-Modified", lastModified.Format(http.TimeFormat))
+		if input.ctx.Header("If-None-Match") != "" || input.ctx.Header("If-Modified-Since") != "" {
+			input.ctx.SetStatus(http.StatusNotModified)
+			return nil, nil
+		}
+		input.ctx.SetHeader("Content-Type", "application/json")
+		_ = json.NewEncoder(input.ctx.BodyWriter()).Encode(map[string]string{"cache": "fresh"})
+		return nil, nil
+	})
+}
+
+type BinaryResponse struct {
+	ContentType string `header:"Content-Type"`
+	Body        []byte
+}
+
+func (s *APIServer) RegisterBytes(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-bytes",
+		Method:      http.MethodGet,
+		Path:        "/bytes/{n}",
+		Summary:     "Return random bytes",
+		Tags:        []string{"Binary"},
+	}, func(ctx context.Context, input *struct {
+		N    int `path:"n" minimum:"1" maximum:"1048576"`
+		Seed int `query:"seed" doc:"Optional deterministic seed"`
+	}) (*BinaryResponse, error) {
+		return &BinaryResponse{ContentType: "application/octet-stream", Body: makeBytes(input.N, input.Seed)}, nil
+	})
+}
+
+func makeBytes(n, seed int) []byte {
+	buf := make([]byte, n)
+	if seed != 0 {
+		r := mathrand.New(mathrand.NewSource(int64(seed)))
+		r.Read(buf)
+		return buf
+	}
+	rand.Read(buf)
+	return buf
+}
+
+func (s *APIServer) RegisterStreamBytes(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-stream-bytes",
+		Method:      http.MethodGet,
+		Path:        "/stream-bytes/{n}",
+		Summary:     "Stream bytes in chunks",
+		Tags:        []string{"Binary"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+		N         int `path:"n" minimum:"1" maximum:"1048576"`
+		ChunkSize int `query:"chunk_size" default:"1024" minimum:"1" maximum:"65536"`
+		Seed      int `query:"seed"`
+	}) (*struct{}, error) {
+		input.ctx.SetHeader("Content-Type", "application/octet-stream")
+		data := makeBytes(input.N, input.Seed)
+		for offset := 0; offset < len(data); offset += input.ChunkSize {
+			end := offset + input.ChunkSize
+			if end > len(data) {
+				end = len(data)
+			}
+			if _, err := input.ctx.BodyWriter().Write(data[offset:end]); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	})
+}
+
+func (s *APIServer) RegisterRange(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-range",
+		Method:      http.MethodGet,
+		Path:        "/range/{n}",
+		Summary:     "Return bytes with Range support",
+		Tags:        []string{"Binary"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+		N int `path:"n" minimum:"1" maximum:"1048576"`
+	}) (*BinaryResponse, error) {
+		data := makeBytes(input.N, 1)
+		if header := input.ctx.Header("Range"); strings.HasPrefix(header, "bytes=") {
+			start, end, ok := parseByteRange(strings.TrimPrefix(header, "bytes="), len(data))
+			if !ok {
+				return nil, huma.NewError(http.StatusRequestedRangeNotSatisfiable, "invalid range")
+			}
+			input.ctx.SetStatus(http.StatusPartialContent)
+			input.ctx.SetHeader("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end-1, len(data)))
+			data = data[start:end]
+		}
+		return &BinaryResponse{ContentType: "application/octet-stream", Body: data}, nil
+	})
+}
+
+func parseByteRange(spec string, length int) (int, int, bool) {
+	startS, endS, ok := strings.Cut(spec, "-")
+	if !ok {
+		return 0, 0, false
+	}
+	start, err := strconv.Atoi(startS)
+	if err != nil || start < 0 || start >= length {
+		return 0, 0, false
+	}
+	end := length
+	if endS != "" {
+		v, err := strconv.Atoi(endS)
+		if err != nil || v < start {
+			return 0, 0, false
+		}
+		end = int(math.Min(float64(v+1), float64(length)))
+	}
+	return start, end, true
+}
+
+func (s *APIServer) RegisterDrip(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-drip",
+		Method:      http.MethodGet,
+		Path:        "/drip",
+		Summary:     "Slowly stream bytes",
+		Tags:        []string{"Binary"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+		NumBytes int    `query:"numbytes" default:"10" minimum:"1" maximum:"10000"`
+		Duration string `query:"duration" default:"2s"`
+		Delay    string `query:"delay" default:"0s"`
+		Code     int    `query:"code" default:"200" minimum:"100" maximum:"599"`
+	}) (*struct{}, error) {
+		delay, err := time.ParseDuration(input.Delay)
+		if err != nil {
+			return nil, huma.Error400BadRequest("invalid delay")
+		}
+		duration, err := time.ParseDuration(input.Duration)
+		if err != nil {
+			return nil, huma.Error400BadRequest("invalid duration")
+		}
+		input.ctx.SetStatus(input.Code)
+		input.ctx.SetHeader("Content-Type", "application/octet-stream")
+		if delay > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		interval := duration / time.Duration(input.NumBytes)
+		if interval < 0 {
+			interval = 0
+		}
+		for i := 0; i < input.NumBytes; i++ {
+			if _, err := input.ctx.BodyWriter().Write([]byte{'*'}); err != nil {
+				return nil, err
+			}
+			if interval > 0 && i < input.NumBytes-1 {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(interval):
+				}
+			}
+		}
+		return nil, nil
+	})
+}
+
+func (s *APIServer) RegisterCompressionFixtures(api huma.API) {
+	for _, route := range []struct {
+		Path     string
+		ID       string
+		Encoding string
+	}{
+		{"/gzip", "get-gzip", "gzip"},
+		{"/deflate", "get-deflate", "deflate"},
+		{"/brotli", "get-brotli", "br"},
+	} {
+		encoding := route.Encoding
+		huma.Register(api, huma.Operation{
+			OperationID: route.ID,
+			Method:      http.MethodGet,
+			Path:        route.Path,
+			Summary:     "Return an explicitly compressed response",
+			Tags:        []string{"Content"},
+		}, func(ctx context.Context, input *struct{}) (*struct {
+			ContentEncoding string `header:"Content-Encoding"`
+			ContentType     string `header:"Content-Type"`
+			Body            []byte
+		}, error) {
+			payload, _ := json.Marshal(map[string]any{"compressed": true, "encoding": encoding})
+			compressed, err := compressBytes(encoding, payload)
+			if err != nil {
+				return nil, err
+			}
+			return &struct {
+				ContentEncoding string `header:"Content-Encoding"`
+				ContentType     string `header:"Content-Type"`
+				Body            []byte
+			}{ContentEncoding: encoding, ContentType: "application/json", Body: compressed}, nil
+		})
+	}
+}
+
+func compressBytes(encoding string, payload []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	switch encoding {
+	case "gzip":
+		w := gzip.NewWriter(&buf)
+		if _, err := w.Write(payload); err != nil {
+			return nil, err
+		}
+		if err := w.Close(); err != nil {
+			return nil, err
+		}
+	case "deflate":
+		w := zlib.NewWriter(&buf)
+		if _, err := w.Write(payload); err != nil {
+			return nil, err
+		}
+		if err := w.Close(); err != nil {
+			return nil, err
+		}
+	case "br":
+		w := brotli.NewWriter(&buf)
+		if _, err := w.Write(payload); err != nil {
+			return nil, err
+		}
+		if err := w.Close(); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func (s *APIServer) RegisterProblem(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-problem",
+		Method:      http.MethodGet,
+		Path:        "/problem",
+		Summary:     "Return an RFC 7807 problem document",
+		Tags:        []string{"Content"},
+	}, func(ctx context.Context, input *struct{}) (*struct {
+		ContentType string `header:"Content-Type"`
+		Status      int
+		Body        map[string]any
+	}, error) {
+		return &struct {
+			ContentType string `header:"Content-Type"`
+			Status      int
+			Body        map[string]any
+		}{ContentType: "application/problem+json", Status: http.StatusBadRequest, Body: map[string]any{
+			"type":   "https://api.rest.sh/problems/example",
+			"title":  "Example problem",
+			"status": http.StatusBadRequest,
+			"detail": "This is a structured problem response for docs.",
+		}}, nil
+	})
+}
+
+func (s *APIServer) RegisterFormats(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-format",
+		Method:      http.MethodGet,
+		Path:        "/formats/{format}",
+		Summary:     "Return data using a specific media type",
+		Tags:        []string{"Content"},
+	}, func(ctx context.Context, input *struct {
+		Format string `path:"format" enum:"json,yaml,cbor,vendor-json"`
+	}) (*struct {
+		ContentType string `header:"Content-Type"`
+		Body        []byte
+	}, error) {
+		contentType := map[string]string{
+			"json":        "application/json",
+			"yaml":        "application/yaml",
+			"cbor":        "application/cbor",
+			"vendor-json": "application/vnd.api+json",
+		}[input.Format]
+		data := map[string]any{"format": input.Format, "ok": true}
+		var body []byte
+		var err error
+		switch input.Format {
+		case "yaml":
+			body, err = yaml.Marshal(data)
+		case "cbor":
+			body, err = cbor.Marshal(data)
+		default:
+			body, err = json.Marshal(data)
+		}
+		if err != nil {
+			return nil, err
+		}
+		return &struct {
+			ContentType string `header:"Content-Type"`
+			Body        []byte
+		}{ContentType: contentType, Body: body}, nil
+	})
+}
+
+func (s *APIServer) RegisterAcceptImage(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-accept-image",
+		Method:      http.MethodGet,
+		Path:        "/image",
+		Summary:     "Return an image based on the Accept header",
+		Tags:        []string{"Images"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*GetImageResponse, error) {
+		accept := input.ctx.Header("Accept")
+		for _, format := range []string{"png", "jpeg", "webp", "gif", "heic"} {
+			if strings.Contains(accept, "image/"+format) {
+				return imageResponse(format), nil
+			}
+		}
+		return imageResponse("png"), nil
+	})
+}
+
+func imageResponse(format string) *GetImageResponse {
+	var body []byte
+	switch format {
+	case "jpeg":
+		body = exampleJPEG
+	case "webp":
+		body = exampleWEBP
+	case "gif":
+		body = exampleGIF
+	case "heic":
+		body = exampleHeic
+	default:
+		format = "png"
+		body = examplePNG
+	}
+	return &GetImageResponse{ContentType: "image/" + format, Body: body}
+}
+
+func (s *APIServer) RegisterUtilityFixtures(api huma.API) {
+	huma.Register(api, huma.Operation{OperationID: "get-cookies", Method: http.MethodGet, Path: "/cookies", Summary: "Return request cookies", Tags: []string{"Utilities"}}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*struct{ Body map[string]map[string]string }, error) {
+		cookies := map[string]string{}
+		for _, part := range strings.Split(input.ctx.Header("Cookie"), ";") {
+			name, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+			if ok && name != "" {
+				cookies[name] = value
+			}
+		}
+		return &struct{ Body map[string]map[string]string }{Body: map[string]map[string]string{"cookies": cookies}}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "get-cookies-set", Method: http.MethodGet, Path: "/cookies/set", Summary: "Set cookies from query parameters", Tags: []string{"Utilities"}}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*struct{ Body map[string]map[string]string }, error) {
+		values, _ := url.ParseQuery(input.ctx.URL().RawQuery)
+		cookies := map[string]string{}
+		for name, vals := range values {
+			value := vals[len(vals)-1]
+			input.ctx.AppendHeader("Set-Cookie", (&http.Cookie{Name: name, Value: value, Path: "/"}).String())
+			cookies[name] = value
+		}
+		return &struct{ Body map[string]map[string]string }{Body: map[string]map[string]string{"cookies": cookies}}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "get-cookies-delete", Method: http.MethodGet, Path: "/cookies/delete", Summary: "Delete cookies named by query parameters", Tags: []string{"Utilities"}}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*struct{ Body map[string][]string }, error) {
+		values, _ := url.ParseQuery(input.ctx.URL().RawQuery)
+		deleted := []string{}
+		for name := range values {
+			input.ctx.AppendHeader("Set-Cookie", (&http.Cookie{Name: name, MaxAge: -1, Path: "/"}).String())
+			deleted = append(deleted, name)
+		}
+		return &struct{ Body map[string][]string }{Body: map[string][]string{"deleted": deleted}}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "get-uuid", Method: http.MethodGet, Path: "/uuid", Summary: "Return a UUID", Tags: []string{"Utilities"}}, func(ctx context.Context, input *struct{}) (*struct{ Body map[string]string }, error) {
+		b := make([]byte, 16)
+		rand.Read(b)
+		b[6] = (b[6] & 0x0f) | 0x40
+		b[8] = (b[8] & 0x3f) | 0x80
+		uuid := fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+		return &struct{ Body map[string]string }{Body: map[string]string{"uuid": uuid}}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "get-ip", Method: http.MethodGet, Path: "/ip", Summary: "Return the requester IP", Tags: []string{"Utilities"}}, func(ctx context.Context, input *struct {
+		RequestInfo
+	}) (*struct{ Body map[string]string }, error) {
+		origin := input.ctx.Header("X-Forwarded-For")
+		if origin == "" {
+			origin = input.ctx.Header("X-Real-IP")
+		}
+		if origin == "" {
+			origin = "unknown"
+		}
+		return &struct{ Body map[string]string }{Body: map[string]string{"origin": origin}}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "get-html", Method: http.MethodGet, Path: "/html", Summary: "Return HTML", Tags: []string{"Utilities"}}, func(ctx context.Context, input *struct{}) (*struct {
+		ContentType string `header:"Content-Type"`
+		Body        []byte
+	}, error) {
+		return &struct {
+			ContentType string `header:"Content-Type"`
+			Body        []byte
+		}{ContentType: "text/html; charset=utf-8", Body: []byte("<!doctype html><title>api.rest.sh</title><h1>Example HTML</h1>")}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "get-xml", Method: http.MethodGet, Path: "/xml", Summary: "Return XML", Tags: []string{"Utilities"}}, func(ctx context.Context, input *struct{}) (*struct {
+		ContentType string `header:"Content-Type"`
+		Body        []byte
+	}, error) {
+		type note struct {
+			XMLName xml.Name `xml:"note"`
+			Message string   `xml:"message"`
+		}
+		b, _ := xml.Marshal(note{Message: "Hello from api.rest.sh"})
+		return &struct {
+			ContentType string `header:"Content-Type"`
+			Body        []byte
+		}{ContentType: "application/xml", Body: b}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "get-base64-encode", Method: http.MethodGet, Path: "/base64/encode/{value}", Summary: "Base64-url encode a value", Tags: []string{"Utilities"}}, func(ctx context.Context, input *struct {
+		Value string `path:"value"`
+	}) (*struct{ Body map[string]string }, error) {
+		encoded := base64.RawURLEncoding.EncodeToString([]byte(input.Value))
+		return &struct{ Body map[string]string }{Body: map[string]string{"encoded": encoded}}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "get-base64-decode", Method: http.MethodGet, Path: "/base64/decode/{value}", Summary: "Base64-url decode a value", Tags: []string{"Utilities"}}, func(ctx context.Context, input *struct {
+		Value string `path:"value"`
+	}) (*struct{ Body map[string]string }, error) {
+		decoded, err := base64.RawURLEncoding.DecodeString(input.Value)
+		if err != nil {
+			decoded, err = base64.StdEncoding.DecodeString(input.Value)
+		}
+		if err != nil {
+			return nil, huma.Error400BadRequest("invalid base64 value")
+		}
+		return &struct{ Body map[string]string }{Body: map[string]string{"decoded": string(decoded)}}, nil
+	})
+}

--- a/fixtures.go
+++ b/fixtures.go
@@ -100,6 +100,7 @@ func (s *APIServer) RegisterUploads(api huma.API) {
 		if err != nil {
 			return nil, huma.Error400BadRequest("invalid multipart body")
 		}
+		defer form.RemoveAll()
 		resp := &UploadResponse{}
 		resp.Body.Fields = form.Value
 		for field, files := range form.File {
@@ -708,19 +709,23 @@ func (s *APIServer) RegisterBytes(api huma.API) {
 		N    int `path:"n" minimum:"1" maximum:"1048576"`
 		Seed int `query:"seed" doc:"Optional deterministic seed"`
 	}) (*BinaryResponse, error) {
-		return &BinaryResponse{ContentType: "application/octet-stream", Body: makeBytes(input.N, input.Seed)}, nil
+		data, err := makeBytes(input.N, input.Seed)
+		if err != nil {
+			return nil, err
+		}
+		return &BinaryResponse{ContentType: "application/octet-stream", Body: data}, nil
 	})
 }
 
-func makeBytes(n, seed int) []byte {
+func makeBytes(n, seed int) ([]byte, error) {
 	buf := make([]byte, n)
 	if seed != 0 {
 		r := mathrand.New(mathrand.NewSource(int64(seed)))
-		r.Read(buf)
-		return buf
+		_, err := r.Read(buf)
+		return buf, err
 	}
-	rand.Read(buf)
-	return buf
+	_, err := io.ReadFull(rand.Reader, buf)
+	return buf, err
 }
 
 func (s *APIServer) RegisterStreamBytes(api huma.API) {
@@ -737,7 +742,10 @@ func (s *APIServer) RegisterStreamBytes(api huma.API) {
 		Seed      int `query:"seed"`
 	}) (*struct{}, error) {
 		input.ctx.SetHeader("Content-Type", "application/octet-stream")
-		data := makeBytes(input.N, input.Seed)
+		data, err := makeBytes(input.N, input.Seed)
+		if err != nil {
+			return nil, err
+		}
 		for offset := 0; offset < len(data); offset += input.ChunkSize {
 			end := offset + input.ChunkSize
 			if end > len(data) {
@@ -762,7 +770,10 @@ func (s *APIServer) RegisterRange(api huma.API) {
 		RequestInfo
 		N int `path:"n" minimum:"1" maximum:"1048576"`
 	}) (*BinaryResponse, error) {
-		data := makeBytes(input.N, 1)
+		data, err := makeBytes(input.N, 1)
+		if err != nil {
+			return nil, err
+		}
 		if header := input.ctx.Header("Range"); strings.HasPrefix(header, "bytes=") {
 			start, end, ok := parseByteRange(strings.TrimPrefix(header, "bytes="), len(data))
 			if !ok {

--- a/fixtures.go
+++ b/fixtures.go
@@ -587,11 +587,13 @@ func (s *APIServer) RegisterRedirects(api huma.API) {
 	} {
 		abs := route.Abs
 		huma.Register(api, huma.Operation{
-			OperationID: route.ID,
-			Method:      http.MethodGet,
-			Path:        route.Path,
-			Summary:     "Redirect a configurable number of times",
-			Tags:        []string{"Redirects"},
+			OperationID:   route.ID,
+			Method:        http.MethodGet,
+			Path:          route.Path,
+			Summary:       "Redirect a configurable number of times",
+			Tags:          []string{"Redirects"},
+			DefaultStatus: http.StatusFound,
+			Responses:     redirectResponses(http.StatusFound),
 		}, func(ctx context.Context, input *struct {
 			RequestInfo
 			N int `path:"n" minimum:"1" maximum:"20"`
@@ -614,11 +616,13 @@ func (s *APIServer) RegisterRedirects(api huma.API) {
 	}
 
 	huma.Register(api, huma.Operation{
-		OperationID: "get-redirect-to",
-		Method:      http.MethodGet,
-		Path:        "/redirect-to",
-		Summary:     "Redirect to a supplied URL",
-		Tags:        []string{"Redirects"},
+		OperationID:   "get-redirect-to",
+		Method:        http.MethodGet,
+		Path:          "/redirect-to",
+		Summary:       "Redirect to a supplied URL",
+		Tags:          []string{"Redirects"},
+		DefaultStatus: http.StatusFound,
+		Responses:     redirectRangeResponses(),
 	}, func(ctx context.Context, input *struct {
 		RequestInfo
 		URL        string `query:"url" required:"true"`
@@ -991,14 +995,63 @@ func (s *APIServer) RegisterAcceptImage(api huma.API) {
 	}, func(ctx context.Context, input *struct {
 		RequestInfo
 	}) (*GetImageResponse, error) {
-		accept := input.ctx.Header("Accept")
-		for _, format := range []string{"png", "jpeg", "webp", "gif", "heic"} {
-			if strings.Contains(accept, "image/"+format) {
-				return imageResponse(format), nil
-			}
+		format, ok := acceptImageFormat(input.ctx.Header("Accept"))
+		if !ok {
+			return nil, huma.Error406NotAcceptable("no acceptable image format")
 		}
-		return imageResponse("png"), nil
+		return imageResponse(format), nil
 	})
+}
+
+func acceptImageFormat(accept string) (string, bool) {
+	if accept == "" {
+		return "png", true
+	}
+
+	formatByMediaType := map[string]string{
+		"image/png":  "png",
+		"image/jpeg": "jpeg",
+		"image/webp": "webp",
+		"image/gif":  "gif",
+		"image/heic": "heic",
+	}
+
+	bestFormat := ""
+	bestQ := 0.0
+	for _, part := range strings.Split(accept, ",") {
+		mediaType, params, err := mime.ParseMediaType(strings.TrimSpace(part))
+		if err != nil {
+			continue
+		}
+
+		format := formatByMediaType[mediaType]
+		if format == "" && (mediaType == "image/*" || mediaType == "*/*") {
+			format = "png"
+		}
+		if format == "" {
+			continue
+		}
+
+		q := 1.0
+		if rawQ := params["q"]; rawQ != "" {
+			parsed, err := strconv.ParseFloat(rawQ, 64)
+			if err != nil {
+				continue
+			}
+			q = parsed
+		}
+		if q <= 0 {
+			continue
+		}
+		if q > bestQ {
+			bestQ = q
+			bestFormat = format
+		}
+	}
+	if bestFormat != "" {
+		return bestFormat, true
+	}
+	return "", false
 }
 
 func imageResponse(format string) *GetImageResponse {

--- a/fixtures.go
+++ b/fixtures.go
@@ -183,8 +183,8 @@ func (s *APIServer) RegisterAuthBearer(api huma.API) {
 	}, func(ctx context.Context, input *struct {
 		RequestInfo
 	}) (*AuthResponse, error) {
-		token := strings.TrimPrefix(input.ctx.Header("Authorization"), "Bearer ")
-		if token == "" {
+		token, ok := strings.CutPrefix(input.ctx.Header("Authorization"), "Bearer ")
+		if !ok || token == "" {
 			return nil, huma.Error401Unauthorized("missing bearer token")
 		}
 		return authOK("bearer", token), nil
@@ -810,9 +810,15 @@ func (s *APIServer) RegisterDrip(api huma.API) {
 		if err != nil {
 			return nil, huma.Error400BadRequest("invalid delay")
 		}
+		if delay < 0 || delay > 10*time.Second {
+			return nil, huma.Error400BadRequest("delay must be between 0s and 10s")
+		}
 		duration, err := time.ParseDuration(input.Duration)
 		if err != nil {
 			return nil, huma.Error400BadRequest("invalid duration")
+		}
+		if duration < 0 || duration > 30*time.Second {
+			return nil, huma.Error400BadRequest("duration must be between 0s and 30s")
 		}
 		input.ctx.SetStatus(input.Code)
 		input.ctx.SetHeader("Content-Type", "application/octet-stream")

--- a/main.go
+++ b/main.go
@@ -160,13 +160,83 @@ type StatusResponse struct {
 	XRetryIn   string `header:"X-Retry-In"`
 }
 
+func stringHeader() *huma.Param {
+	return &huma.Param{Schema: &huma.Schema{Type: "string"}}
+}
+
+func errorResponse() *huma.Response {
+	return &huma.Response{
+		Description: "Error",
+		Content: map[string]*huma.MediaType{
+			"application/problem+json": {
+				Schema: &huma.Schema{Ref: "#/components/schemas/ErrorModel"},
+			},
+		},
+	}
+}
+
+func statusText(code int) string {
+	if text := http.StatusText(code); text != "" {
+		return text
+	}
+	return fmt.Sprintf("Status %d", code)
+}
+
+func statusFixtureResponses() map[string]*huma.Response {
+	responses := map[string]*huma.Response{
+		"default": errorResponse(),
+	}
+	for code := 100; code <= 599; code++ {
+		responses[fmt.Sprintf("%d", code)] = &huma.Response{
+			Description: statusText(code),
+			Headers: map[string]*huma.Param{
+				"Retry-After": stringHeader(),
+				"X-Retry-In":  stringHeader(),
+			},
+		}
+	}
+	return responses
+}
+
+func redirectResponses(codes ...int) map[string]*huma.Response {
+	responses := map[string]*huma.Response{
+		"default": errorResponse(),
+	}
+	for _, code := range codes {
+		responses[fmt.Sprintf("%d", code)] = &huma.Response{
+			Description: statusText(code),
+			Headers: map[string]*huma.Param{
+				"Location": stringHeader(),
+			},
+		}
+	}
+	return responses
+}
+
+func redirectRangeResponses() map[string]*huma.Response {
+	responses := map[string]*huma.Response{
+		"default": errorResponse(),
+	}
+	for code := 300; code <= 399; code++ {
+		responses[fmt.Sprintf("%d", code)] = &huma.Response{
+			Description: statusText(code),
+			Headers: map[string]*huma.Param{
+				"Location": stringHeader(),
+			},
+		}
+	}
+	return responses
+}
+
 func (s *APIServer) RegisterStatus(api huma.API) {
 	huma.Register(api, huma.Operation{
-		OperationID: "get-status",
-		Method:      http.MethodGet,
-		Path:        "/status/{code}",
-		Description: "Status code example",
-		Tags:        []string{"Status"},
+		OperationID:   "get-status",
+		Method:        http.MethodGet,
+		Path:          "/status/{code}",
+		Description:   "Status code example",
+		Tags:          []string{"Status"},
+		DefaultStatus: http.StatusOK,
+		Responses:     statusFixtureResponses(),
 	}, func(ctx context.Context, input *struct {
 		Code       int    `path:"code" minimum:"100" maximum:"599" doc:"Status code to return"`
 		RetryAfter string `query:"retry-after" doc:"Retry-After header value"`

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ Provides a simple, modern, example API that offers these features:
 	- Shows off ^object^, ^array^, ^string^, ^date^, ^binary^, ^integer^, ^number^, ^boolean^, etc.
 - A sample CRUD API for books & reviews with simulated server-side updates
 - Image responses ^JPEG^, ^WEBP^, ^GIF^, ^PNG^ & ^HEIC^
+- [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) streaming with JSON events
 - [RFC7807](https://datatracker.ietf.org/doc/html/rfc7807) structured errors
 
 This project is open source: [https://github.com/danielgtaylor/apibin](https://github.com/danielgtaylor/apibin)
@@ -330,7 +331,7 @@ func main() {
 			Addr:              fmt.Sprintf("%s:%d", opts.Host, opts.Port),
 			ReadTimeout:       5 * time.Second,
 			ReadHeaderTimeout: 1 * time.Second,
-			WriteTimeout:      10 * time.Second,
+			WriteTimeout:      0, // SSE streams require no write deadline
 			IdleTimeout:       30 * time.Second,
 			Handler:           router,
 		}

--- a/main.go
+++ b/main.go
@@ -413,7 +413,7 @@ func main() {
 			Addr:              fmt.Sprintf("%s:%d", opts.Host, opts.Port),
 			ReadTimeout:       5 * time.Second,
 			ReadHeaderTimeout: 1 * time.Second,
-			WriteTimeout:      0, // SSE streams require no write deadline
+			WriteTimeout:      5 * time.Minute, // Allow long-lived streams without disabling write deadlines globally
 			IdleTimeout:       30 * time.Second,
 			Handler:           router,
 		}

--- a/main.go
+++ b/main.go
@@ -31,11 +31,14 @@ Provides a simple, modern, example API that offers these features:
 - Conditional requests via ^ETag^ or ^LastModified^
 - Echo back request info to help debugging
 - Cached responses to test proxy & client-side caching
+- Auth, form, multipart upload, redirect, retry, timeout, cookie, and header fixtures
 - Example structured data
 	- Shows off ^object^, ^array^, ^string^, ^date^, ^binary^, ^integer^, ^number^, ^boolean^, etc.
 - A sample CRUD API for books & reviews with simulated server-side updates
+- A resettable sample CRUD API for docs-oriented item examples
 - Image responses ^JPEG^, ^WEBP^, ^GIF^, ^PNG^ & ^HEIC^
-- [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) streaming with JSON events
+- [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) and NDJSON streaming with JSON events
+- Byte streams, range requests, explicit compression fixtures, and content negotiation examples
 - [RFC7807](https://datatracker.ietf.org/doc/html/rfc7807) structured errors
 
 This project is open source: [https://github.com/danielgtaylor/apibin](https://github.com/danielgtaylor/apibin)
@@ -190,7 +193,11 @@ func (s *APIServer) RegisterListImages(api huma.API) {
 		Description: "List available images",
 		Tags:        []string{"Images"},
 	}, func(ctx context.Context, input *struct {
-		Cursor string `query:"cursor" doc:"Pagination cursor"`
+		Cursor  string `query:"cursor" doc:"Pagination cursor"`
+		Format  string `query:"format" enum:"jpeg,webp,gif,png,heic" doc:"Filter by image format"`
+		Search  string `query:"search" doc:"Case-insensitive search over image names"`
+		Limit   int    `query:"limit" minimum:"1" maximum:"5" doc:"Maximum number of images to return"`
+		PerPage int    `query:"per_page" minimum:"1" maximum:"5" doc:"Alias for limit"`
 	}) (*ListImagesResponse, error) {
 		// Return different pages based on the cursor.
 		resp := &ListImagesResponse{}
@@ -230,8 +237,29 @@ func (s *APIServer) RegisterListImages(api huma.API) {
 				},
 			}
 		}
+		resp.Body = filterImages(resp.Body, input.Format, input.Search, input.Limit, input.PerPage)
 		return resp, nil
 	})
+}
+
+func filterImages(images []ImageItem, format, search string, limit, perPage int) []ImageItem {
+	if perPage > 0 {
+		limit = perPage
+	}
+	filtered := images[:0]
+	for _, image := range images {
+		if format != "" && image.Format != format {
+			continue
+		}
+		if search != "" && !strings.Contains(strings.ToLower(image.Name), strings.ToLower(search)) {
+			continue
+		}
+		filtered = append(filtered, image)
+		if limit > 0 && len(filtered) >= limit {
+			break
+		}
+	}
+	return filtered
 }
 
 type GetImageResponse struct {
@@ -249,23 +277,7 @@ func (s *APIServer) RegisterGetImage(api huma.API) {
 	}, func(ctx context.Context, i *struct {
 		Type string `path:"type" enum:"jpeg,webp,png,gif,heic"`
 	}) (*GetImageResponse, error) {
-		var body []byte
-		switch i.Type {
-		case "jpeg":
-			body = exampleJPEG
-		case "webp":
-			body = exampleWEBP
-		case "png":
-			body = examplePNG
-		case "gif":
-			body = exampleGIF
-		case "heic":
-			body = exampleHeic
-		}
-		return &GetImageResponse{
-			ContentType: "image/" + i.Type,
-			Body:        body,
-		}, nil
+		return imageResponse(i.Type), nil
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func filterImages(images []ImageItem, format, search string, limit, perPage int)
 	if perPage > 0 {
 		limit = perPage
 	}
-	filtered := images[:0]
+	filtered := make([]ImageItem, 0, len(images))
 	for _, image := range images {
 		if format != "" && image.Format != format {
 			continue

--- a/sse.go
+++ b/sse.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/rand"
@@ -32,7 +33,38 @@ type AlertEvent struct {
 	Message   string    `json:"message" doc:"Human-readable alert description"`
 }
 
+// DocsUser identifies a user in docs-oriented stream examples.
+type DocsUser struct {
+	ID   string `json:"id" doc:"User ID"`
+	Name string `json:"name" doc:"Display name"`
+}
+
+// DocsEvent is a simple event shape for streaming documentation examples.
+type DocsEvent struct {
+	Type      string    `json:"type" enum:"login,update,logout" doc:"Event type"`
+	User      DocsUser  `json:"user" doc:"User associated with the event"`
+	Message   string    `json:"message" doc:"Human-readable message"`
+	Timestamp time.Time `json:"timestamp" doc:"Event timestamp"`
+}
+
 var regions = []string{"us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"}
+var docsEventTypes = []string{"login", "update", "logout"}
+var docsUsers = []DocsUser{
+	{ID: "u_123", Name: "Alice"},
+	{ID: "u_456", Name: "Sam"},
+	{ID: "u_789", Name: "Morgan"},
+}
+
+func docsEvent(i int) DocsEvent {
+	user := docsUsers[i%len(docsUsers)]
+	eventType := docsEventTypes[i%len(docsEventTypes)]
+	return DocsEvent{
+		Type:      eventType,
+		User:      user,
+		Message:   fmt.Sprintf("%s event for %s", eventType, user.Name),
+		Timestamp: time.Now().UTC(),
+	}
+}
 
 // metricSimulator holds running state so values drift realistically between samples.
 type metricSimulator struct {
@@ -165,5 +197,70 @@ func (s *APIServer) RegisterSSE(api huma.API) {
 				}
 			}
 		}
+	})
+}
+
+func (s *APIServer) RegisterEvents(api huma.API) {
+	sse.Register(api, huma.Operation{
+		OperationID: "get-events",
+		Method:      http.MethodGet,
+		Path:        "/events",
+		Summary:     "Stream simple docs events",
+		Description: "Streams a bounded Server-Sent Events feed with a simple `type`, `user.id`, `message`, and `timestamp` shape for documentation examples.",
+		Tags:        []string{"SSE"},
+	}, map[string]any{
+		"event": DocsEvent{},
+	}, func(ctx context.Context, input *struct {
+		Count int `query:"count" minimum:"1" maximum:"100" default:"10" doc:"Number of events to emit"`
+	}, send sse.Sender) {
+		count := input.Count
+		if count == 0 {
+			count = 10
+		}
+		for i := 0; i < count; i++ {
+			if err := send.Data(docsEvent(i)); err != nil {
+				return
+			}
+			if i < count-1 {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(250 * time.Millisecond):
+				}
+			}
+		}
+	})
+}
+
+func (s *APIServer) RegisterLogs(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-logs",
+		Method:      http.MethodGet,
+		Path:        "/logs",
+		Summary:     "Stream newline-delimited JSON logs",
+		Tags:        []string{"Streaming"},
+	}, func(ctx context.Context, input *struct {
+		RequestInfo
+		Count int `query:"count" minimum:"1" maximum:"100" default:"10" doc:"Number of log lines to emit"`
+	}) (*struct{}, error) {
+		count := input.Count
+		if count == 0 {
+			count = 10
+		}
+		input.ctx.SetHeader("Content-Type", "application/x-ndjson")
+		enc := json.NewEncoder(input.ctx.BodyWriter())
+		for i := 0; i < count; i++ {
+			if err := enc.Encode(docsEvent(i)); err != nil {
+				return nil, err
+			}
+			if i < count-1 {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(250 * time.Millisecond):
+				}
+			}
+		}
+		return nil, nil
 	})
 }

--- a/sse.go
+++ b/sse.go
@@ -104,13 +104,16 @@ func (m *metricSimulator) next() MetricEvent {
 	}
 	m.rps = clamp(m.rps+rand.Float64()*60-30, 0, 2000)
 
+	region := regions[m.regionIdx%len(regions)]
+	m.regionIdx = (m.regionIdx + 1) % len(regions)
+
 	return MetricEvent{
 		Timestamp:      time.Now().UTC(),
 		CPUPercent:     math.Round(m.cpu*10) / 10,
 		MemoryPercent:  math.Round(m.mem*10) / 10,
 		ActiveConns:    m.conns,
 		RequestsPerSec: math.Round(m.rps*10) / 10,
-		Region:         regions[m.regionIdx%len(regions)],
+		Region:         region,
 	}
 }
 

--- a/sse.go
+++ b/sse.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/sse"
+)
+
+// MetricEvent represents a snapshot of simulated server metrics.
+type MetricEvent struct {
+	Timestamp      time.Time `json:"timestamp" doc:"Time the metrics were sampled"`
+	CPUPercent     float64   `json:"cpu_percent" doc:"CPU utilization percentage" minimum:"0" maximum:"100"`
+	MemoryPercent  float64   `json:"memory_percent" doc:"Memory utilization percentage" minimum:"0" maximum:"100"`
+	ActiveConns    int       `json:"active_connections" doc:"Number of active HTTP connections"`
+	RequestsPerSec float64   `json:"requests_per_second" doc:"Inbound request rate"`
+	Region         string    `json:"region" doc:"Data center region reporting metrics"`
+}
+
+// AlertEvent is emitted when a metric crosses a warning or critical threshold.
+type AlertEvent struct {
+	Timestamp time.Time `json:"timestamp" doc:"Time the alert was raised"`
+	Severity  string    `json:"severity" enum:"warning,critical" doc:"Alert severity level"`
+	Metric    string    `json:"metric" doc:"Name of the metric that triggered the alert"`
+	Value     float64   `json:"value" doc:"Current value of the metric"`
+	Threshold float64   `json:"threshold" doc:"Threshold that was exceeded"`
+	Message   string    `json:"message" doc:"Human-readable alert description"`
+}
+
+var regions = []string{"us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"}
+
+// metricSimulator holds running state so values drift realistically between samples.
+type metricSimulator struct {
+	cpu       float64
+	mem       float64
+	conns     int
+	rps       float64
+	regionIdx int
+}
+
+func newMetricSimulator() *metricSimulator {
+	return &metricSimulator{
+		cpu:   55 + rand.Float64()*20,
+		mem:   60 + rand.Float64()*15,
+		conns: 80 + rand.Intn(40),
+		rps:   300 + rand.Float64()*200,
+	}
+}
+
+func clamp(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+func (m *metricSimulator) next() MetricEvent {
+	// Apply a random walk to each metric so the stream looks like real telemetry.
+	m.cpu = clamp(m.cpu+rand.Float64()*20-10, 2, 98)
+	m.mem = clamp(m.mem+rand.Float64()*10-5, 10, 95)
+	m.conns += rand.Intn(21) - 10
+	if m.conns < 0 {
+		m.conns = 0
+	}
+	m.rps = clamp(m.rps+rand.Float64()*60-30, 0, 2000)
+
+	return MetricEvent{
+		Timestamp:      time.Now().UTC(),
+		CPUPercent:     math.Round(m.cpu*10) / 10,
+		MemoryPercent:  math.Round(m.mem*10) / 10,
+		ActiveConns:    m.conns,
+		RequestsPerSec: math.Round(m.rps*10) / 10,
+		Region:         regions[m.regionIdx%len(regions)],
+	}
+}
+
+func (s *APIServer) RegisterSSE(api huma.API) {
+	sse.Register(api, huma.Operation{
+		OperationID: "get-sse-metrics",
+		Method:      http.MethodGet,
+		Path:        "/sse/metrics",
+		Summary:     "Stream server metrics",
+		Description: "Streams simulated server metrics as a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) (SSE) stream. Each event is a JSON object with CPU, memory, connection, and request-rate fields sampled from a random walk to mimic real telemetry.",
+		Tags:        []string{"SSE"},
+	}, map[string]any{
+		"metrics": MetricEvent{},
+		"alert":   AlertEvent{},
+	}, func(ctx context.Context, input *struct {
+		Count int `query:"count" minimum:"1" maximum:"100" default:"10" doc:"Number of metric events to emit before closing the stream"`
+	}, send sse.Sender) {
+		count := input.Count
+		if count == 0 {
+			count = 10
+		}
+		sim := newMetricSimulator()
+
+		for i := 0; i < count; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			event := sim.next()
+			if err := send.Data(event); err != nil {
+				return
+			}
+
+			// Emit alert events when metrics cross thresholds.
+			now := event.Timestamp
+			type check struct {
+				metric   string
+				value    float64
+				warning  float64
+				critical float64
+				unit     string
+			}
+			checks := []check{
+				{"cpu_percent", event.CPUPercent, 60, 80, "%"},
+				{"memory_percent", event.MemoryPercent, 65, 80, "%"},
+			}
+			for _, c := range checks {
+				var severity, msg string
+				switch {
+				case c.value >= c.critical:
+					severity = "critical"
+					msg = fmt.Sprintf("%s is critically high at %.1f%s (threshold: %.0f%s)", c.metric, c.value, c.unit, c.critical, c.unit)
+				case c.value >= c.warning:
+					severity = "warning"
+					msg = fmt.Sprintf("%s is elevated at %.1f%s (threshold: %.0f%s)", c.metric, c.value, c.unit, c.warning, c.unit)
+				}
+				if severity != "" {
+					threshold := c.warning
+					if severity == "critical" {
+						threshold = c.critical
+					}
+					if err := send(sse.Message{Data: AlertEvent{
+						Timestamp: now,
+						Severity:  severity,
+						Metric:    c.metric,
+						Value:     c.value,
+						Threshold: threshold,
+						Message:   msg,
+					}}); err != nil {
+						return
+					}
+				}
+			}
+
+			if i < count-1 {
+				// Wait 500 ms – 2 s before the next event.
+				delay := time.Duration(500+rand.Intn(1500)) * time.Millisecond
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(delay):
+				}
+			}
+		}
+	})
+}

--- a/sse.go
+++ b/sse.go
@@ -213,15 +213,11 @@ func (s *APIServer) RegisterEvents(api huma.API) {
 	}, func(ctx context.Context, input *struct {
 		Count int `query:"count" minimum:"1" maximum:"100" default:"10" doc:"Number of events to emit"`
 	}, send sse.Sender) {
-		count := input.Count
-		if count == 0 {
-			count = 10
-		}
-		for i := 0; i < count; i++ {
+		for i := 0; i < input.Count; i++ {
 			if err := send.Data(docsEvent(i)); err != nil {
 				return
 			}
-			if i < count-1 {
+			if i < input.Count-1 {
 				select {
 				case <-ctx.Done():
 					return
@@ -243,17 +239,13 @@ func (s *APIServer) RegisterLogs(api huma.API) {
 		RequestInfo
 		Count int `query:"count" minimum:"1" maximum:"100" default:"10" doc:"Number of log lines to emit"`
 	}) (*struct{}, error) {
-		count := input.Count
-		if count == 0 {
-			count = 10
-		}
 		input.ctx.SetHeader("Content-Type", "application/x-ndjson")
 		enc := json.NewEncoder(input.ctx.BodyWriter())
-		for i := 0; i < count; i++ {
+		for i := 0; i < input.Count; i++ {
 			if err := enc.Encode(docsEvent(i)); err != nil {
 				return nil, err
 			}
-			if i < count-1 {
+			if i < input.Count-1 {
 				select {
 				case <-ctx.Done():
 					return nil, ctx.Err()


### PR DESCRIPTION
## Summary
- add SSE, docs-oriented, auth, upload, redirect, binary, image, content, and utility fixtures
- fix ETag header quoting while preserving conditional request comparisons
- document dynamic status and redirect responses in OpenAPI
- add broad in-process regression coverage for API behavior and middleware

## Validation
- env GOCACHE=/tmp/apibin-gocache go test ./...
- env GOCACHE=/tmp/apibin-gocache go vet ./...
- env GOCACHE=/tmp/apibin-gocache go test -cover ./...