### PR TITLE
Disable buffering for streaming endpoints

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -48,6 +48,7 @@ func newTestHandler(t *testing.T) (http.Handler, huma.API) {
 	router := chi.NewMux()
 	router.Use(ResponseGuard)
 	router.Use(CORS)
+	router.Use(StreamingHeaders)
 	router.Use(ContentEncoding)
 	api := humachi.New(router, config)
 
@@ -465,6 +466,22 @@ func TestStreamingEndpoints(t *testing.T) {
 	assertHeader(t, resp, "Content-Type", "application/x-ndjson")
 	if !strings.Contains(resp.Body.String(), `"type":"login"`) {
 		t.Fatalf("logs response mismatch: %s", resp.Body.String())
+	}
+}
+
+func TestStreamingEndpointsDisableProxyBuffering(t *testing.T) {
+	api := newTestAPI(t)
+
+	for _, path := range []string{
+		"/sse/metrics?count=1",
+		"/events?count=1",
+		"/logs?count=1",
+	} {
+		resp := api.Get(path)
+		assertStatus(t, resp, http.StatusOK)
+		assertHeader(t, resp, "Cache-Control", "no-cache, no-store, no-transform")
+		assertHeader(t, resp, "Surrogate-Control", "no-store")
+		assertHeader(t, resp, "X-Accel-Buffering", "no")
 	}
 }
 

--- a/compress.go
+++ b/compress.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"path"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/andybalholm/brotli"
@@ -21,7 +20,6 @@ const brotliEncoding = "br"
 
 var supportedEncodings []string = []string{brotliEncoding, gzipEncoding}
 var compressDenyList []string = []string{".gif", ".png", ".jpg", ".jpeg", ".zip", ".gz", ".bz2"}
-var compressDenyPaths []string = []string{"/sse/metrics", "/events", "/logs", "/stream-bytes", "/drip"}
 
 type contentEncodingWriter struct {
 	http.ResponseWriter
@@ -132,12 +130,10 @@ func ContentEncoding(next http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for _, deny := range compressDenyPaths {
-			if strings.HasPrefix(r.URL.Path, deny) {
-				// This is a path we should not try to compress.
-				next.ServeHTTP(w, r)
-				return
-			}
+		if isStreamingPath(r.URL.Path) {
+			// This is a path we should not try to compress.
+			next.ServeHTTP(w, r)
+			return
 		}
 
 		if ext := path.Ext(r.URL.Path); ext != "" {

--- a/main.go
+++ b/main.go
@@ -365,6 +365,7 @@ func main() {
 		router.Use(middleware.Recoverer)
 		router.Use(ResponseGuard)
 		router.Use(CORS)
+		router.Use(StreamingHeaders)
 		router.Use(ContentEncoding)
 
 		router.Use(func(next http.Handler) http.Handler {

--- a/streaming.go
+++ b/streaming.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+var streamingPaths = []string{"/sse/metrics", "/events", "/logs", "/stream-bytes", "/drip"}
+
+func isStreamingPath(path string) bool {
+	for _, streamPath := range streamingPaths {
+		if strings.HasPrefix(path, streamPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// StreamingHeaders marks streaming responses so intermediaries do not buffer,
+// transform, or cache them before forwarding data to clients.
+func StreamingHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isStreamingPath(r.URL.Path) {
+			header := w.Header()
+			header.Set("Cache-Control", "no-cache, no-store, no-transform")
+			header.Set("Surrogate-Control", "no-store")
+			header.Set("X-Accel-Buffering", "no")
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
This pull request improves handling of streaming endpoints by introducing a new middleware to set appropriate HTTP headers, ensuring proper behavior with proxies and clients. It also refactors the logic for identifying streaming paths and updates the compression middleware to use this new logic. Additionally, new tests are added to verify the correct headers are set for streaming endpoints.

**Streaming endpoints handling:**

* Added a new `StreamingHeaders` middleware in `streaming.go` that sets headers (`Cache-Control`, `Surrogate-Control`, and `X-Accel-Buffering`) to prevent buffering, transformation, or caching of streaming responses by intermediaries. This middleware is now applied in both the main application and test setup. [[1]](diffhunk://#diff-64464c17ff409e67384719074a5ca639336a84be27a28976a496010d035ef87cR1-R32) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R368) [[3]](diffhunk://#diff-9a6ab27c824fb3a6082d5d518db17f3c310f1eff5def98ca5f5158309e92a08bR51)
* Refactored the logic for identifying streaming paths into a new `isStreamingPath` function in `streaming.go`, replacing the previous `compressDenyPaths` list and related string logic. [[1]](diffhunk://#diff-64464c17ff409e67384719074a5ca639336a84be27a28976a496010d035ef87cR1-R32) [[2]](diffhunk://#diff-4899b3b3a87185e976cf18ba1751af96d52ad02186cf6a4bc62e438feafd8d31L24) [[3]](diffhunk://#diff-4899b3b3a87185e976cf18ba1751af96d52ad02186cf6a4bc62e438feafd8d31L135-L141)

**Testing improvements:**

* Added a new test `TestStreamingEndpointsDisableProxyBuffering` in `api_test.go` to verify that the correct headers are set for streaming endpoints.

**Code cleanup:**

* Removed an unused import of `"strings"` from `compress.go` as the logic was moved to `streaming.go`.