### PR TITLE
[codex] Add body echo endpoint and schema docs

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -642,6 +642,16 @@ func TestOpenAPIAndHelperCoverage(t *testing.T) {
 	if paths["/redirect-to"].Get.Responses["307"] == nil || paths["/redirect-to"].Get.Responses["399"] == nil {
 		t.Fatal("OpenAPI should document redirect-to status range")
 	}
+	foundRedirectURLParam := false
+	for _, param := range paths["/redirect-to"].Get.Parameters {
+		if param.Name == "url" && param.In == "query" && param.Schema != nil && param.Schema.Format == "uri-reference" && param.Example == "/get" {
+			foundRedirectURLParam = true
+			break
+		}
+	}
+	if !foundRedirectURLParam {
+		t.Fatal("OpenAPI should document redirect-to URL as a URI reference")
+	}
 	if paths["/redirect/{n}"].Get.Responses["302"].Headers["Location"] == nil {
 		t.Fatal("OpenAPI should document redirect Location header")
 	}
@@ -755,6 +765,10 @@ func TestOpenAPISchemaMetadata(t *testing.T) {
 	metrics := schemaFor(t, schemas, "MetricEvent")
 	assertEnum(t, propertyFor(t, metrics, "region"), []any{"us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"})
 	assertFloatPtr(t, propertyFor(t, metrics, "requests_per_second").Maximum, 2000, "MetricEvent.requests_per_second maximum")
+
+	alert := schemaFor(t, schemas, "AlertEvent")
+	assertExample(t, propertyFor(t, alert, "severity"), "critical")
+	assertExample(t, propertyFor(t, alert, "message"), "cpu_percent is critically high at 82.3% (threshold: 80%)")
 }
 
 func schemaFor(t *testing.T, schemas map[string]*huma.Schema, name string) *huma.Schema {

--- a/api_test.go
+++ b/api_test.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -166,6 +167,13 @@ func TestCoreContentAndInspectionEndpoints(t *testing.T) {
 	assertStatus(t, resp, http.StatusOK)
 	if !strings.Contains(resp.Body.String(), `"parsed":{"hello":"world"}`) {
 		t.Fatalf("echo response missing raw body: %s", resp.Body.String())
+	}
+
+	resp = api.Post("/body", map[string]any{"some": "data"})
+	assertStatus(t, resp, http.StatusOK)
+	body = decodeJSON(t, resp)
+	if !reflect.DeepEqual(body, map[string]any{"some": "data"}) {
+		t.Fatalf("body response mismatch: %#v", body)
 	}
 }
 
@@ -700,6 +708,108 @@ func TestOpenAPIAndHelperCoverage(t *testing.T) {
 	second := sim.next().Region
 	if first == second {
 		t.Fatalf("metric simulator should rotate regions, got %q twice", first)
+	}
+}
+
+func TestOpenAPISchemaMetadata(t *testing.T) {
+	api := newTestAPI(t)
+	schemas := api.OpenAPI().Components.Schemas.Map()
+
+	typesModel := schemaFor(t, schemas, "TypesModel")
+	assertSchemaDescription(t, propertyFor(t, typesModel, "integer"), "Integer example with validation bounds")
+	assertFloatPtr(t, propertyFor(t, typesModel, "integer").Minimum, 0, "TypesModel.integer minimum")
+	assertFloatPtr(t, propertyFor(t, typesModel, "integer").Maximum, 100, "TypesModel.integer maximum")
+	assertFloatPtr(t, propertyFor(t, typesModel, "number").MultipleOf, 0.01, "TypesModel.number multipleOf")
+	assertIntPtr(t, propertyFor(t, typesModel, "string").MinLength, 1, "TypesModel.string minLength")
+	assertExample(t, propertyFor(t, typesModel, "string"), "Hello, world!")
+	assertIntPtr(t, propertyFor(t, typesModel, "tags").MinItems, 1, "TypesModel.tags minItems")
+	assertIntPtr(t, propertyFor(t, typesModel, "tags").MaxItems, 5, "TypesModel.tags maxItems")
+	if !propertyFor(t, typesModel, "tags").UniqueItems {
+		t.Fatal("TypesModel.tags should require unique items")
+	}
+
+	subObject := schemaFor(t, schemas, "SubObject")
+	assertSchemaDescription(t, propertyFor(t, subObject, "binary"), "Small binary payload encoded as base64 in JSON")
+	assertIntPtr(t, propertyFor(t, subObject, "binary").MinLength, 1, "SubObject.binary minLength")
+	assertExample(t, propertyFor(t, subObject, "url"), "https://rest.sh/")
+
+	book := schemaFor(t, schemas, "Book")
+	assertSchemaDescription(t, propertyFor(t, book, "title"), "Book title")
+	assertIntPtr(t, propertyFor(t, book, "title").MaxLength, 200, "Book.title maxLength")
+	assertFloatPtr(t, propertyFor(t, book, "rating_average").Maximum, 5, "Book.rating_average maximum")
+
+	item := schemaFor(t, schemas, "Item")
+	assertSchemaDescription(t, propertyFor(t, item, "id"), "Stable item identifier; omit or leave empty when creating an item to have one generated")
+	assertIntPtr(t, propertyFor(t, item, "id").MaxLength, 64, "Item.id maxLength")
+	if !propertyFor(t, item, "tags").UniqueItems {
+		t.Fatal("Item.tags should require unique items")
+	}
+
+	image := schemaFor(t, schemas, "ImageItem")
+	assertEnum(t, propertyFor(t, image, "format"), []any{"jpeg", "webp", "gif", "png", "heic"})
+	assertExample(t, propertyFor(t, image, "self"), "/image/jpeg")
+
+	auth := schemaFor(t, schemas, "AuthResponseBody")
+	assertEnum(t, propertyFor(t, auth, "scheme"), []any{"basic", "bearer", "api-key-header", "api-key-query"})
+
+	metrics := schemaFor(t, schemas, "MetricEvent")
+	assertEnum(t, propertyFor(t, metrics, "region"), []any{"us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"})
+	assertFloatPtr(t, propertyFor(t, metrics, "requests_per_second").Maximum, 2000, "MetricEvent.requests_per_second maximum")
+}
+
+func schemaFor(t *testing.T, schemas map[string]*huma.Schema, name string) *huma.Schema {
+	t.Helper()
+	schema := schemas[name]
+	if schema == nil {
+		t.Fatalf("missing schema %q", name)
+	}
+	return schema
+}
+
+func propertyFor(t *testing.T, schema *huma.Schema, name string) *huma.Schema {
+	t.Helper()
+	property := schema.Properties[name]
+	if property == nil {
+		t.Fatalf("missing property %q", name)
+	}
+	return property
+}
+
+func assertSchemaDescription(t *testing.T, schema *huma.Schema, want string) {
+	t.Helper()
+	if schema.Description != want {
+		t.Fatalf("description = %q, want %q", schema.Description, want)
+	}
+}
+
+func assertExample(t *testing.T, schema *huma.Schema, want any) {
+	t.Helper()
+	for _, example := range schema.Examples {
+		if reflect.DeepEqual(example, want) {
+			return
+		}
+	}
+	t.Fatalf("examples = %#v, want one matching %#v", schema.Examples, want)
+}
+
+func assertEnum(t *testing.T, schema *huma.Schema, want []any) {
+	t.Helper()
+	if !reflect.DeepEqual(schema.Enum, want) {
+		t.Fatalf("enum = %#v, want %#v", schema.Enum, want)
+	}
+}
+
+func assertFloatPtr(t *testing.T, got *float64, want float64, name string) {
+	t.Helper()
+	if got == nil || *got != want {
+		t.Fatalf("%s = %v, want %v", name, got, want)
+	}
+}
+
+func assertIntPtr(t *testing.T, got *int, want int, name string) {
+	t.Helper()
+	if got == nil || *got != want {
+		t.Fatalf("%s = %v, want %v", name, got, want)
 	}
 }
 

--- a/books.go
+++ b/books.go
@@ -19,18 +19,18 @@ import (
 
 // Rating is a point-in-time rating for a book.
 type Rating struct {
-	Date   time.Time `json:"date"`
-	Rating float64   `json:"rating"`
+	Date   time.Time `json:"date" doc:"Time when the rating was recorded"`
+	Rating float64   `json:"rating" minimum:"0" maximum:"5" multipleOf:"0.1" doc:"Rating value on a 0 to 5 scale" example:"4.6"`
 }
 
 // Book tracks metadata information about a book and its ratings.
 type Book struct {
-	Title         string    `json:"title"`
-	Author        string    `json:"author,omitempty"`
-	Published     time.Time `json:"published,omitempty"`
-	Ratings       int       `json:"ratings,omitempty"`
-	RatingAverage float64   `json:"rating_average,omitempty"`
-	RecentRatings []Rating  `json:"recent_ratings,omitempty"`
+	Title         string    `json:"title" minLength:"1" maxLength:"200" doc:"Book title" example:"The Left Hand of Darkness"`
+	Author        string    `json:"author,omitempty" minLength:"1" maxLength:"120" doc:"Primary author" example:"Ursula K. Le Guin"`
+	Published     time.Time `json:"published,omitempty" doc:"Publication date"`
+	Ratings       int       `json:"ratings,omitempty" minimum:"0" doc:"Total number of ratings" example:"1287"`
+	RatingAverage float64   `json:"rating_average,omitempty" minimum:"0" maximum:"5" multipleOf:"0.1" doc:"Average rating on a 0 to 5 scale" example:"4.4"`
+	RecentRatings []Rating  `json:"recent_ratings,omitempty" maxItems:"10" doc:"Most recent rating samples"`
 	modified      time.Time `json:"-"`
 }
 
@@ -47,9 +47,9 @@ func (b Book) Version() string {
 
 // BookSummary provides a link and version for the books list response.
 type BookSummary struct {
-	URL      string    `json:"url"`
-	Version  string    `json:"version"`
-	Modified time.Time `json:"modified"`
+	URL      string    `json:"url" format:"uri-reference" doc:"Relative URL for the book resource" example:"/books/left-hand-of-darkness"`
+	Version  string    `json:"version" doc:"Opaque version token for conditional requests" example:"F5D3XF8rF2F="`
+	Modified time.Time `json:"modified" doc:"Last modification time used for conditional requests"`
 }
 
 // booksMu controls access to the map/slice. This is necessary because maps &
@@ -155,7 +155,7 @@ func (s *APIServer) RegisterGetBook(api huma.API) {
 		Tags:        []string{"Books"},
 	}, func(ctx context.Context, input *struct {
 		conditional.Params
-		ID string `path:"book-id"`
+		ID string `path:"book-id" doc:"Book identifier" example:"sapiens"`
 	}) (*GetBookResponse, error) {
 		booksMu.RLock()
 		defer booksMu.RUnlock()
@@ -188,7 +188,7 @@ func (s *APIServer) RegisterPutBook(api huma.API) {
 		Tags:        []string{"Books"},
 	}, func(ctx context.Context, input *struct {
 		conditional.Params
-		ID   string `path:"book-id"`
+		ID   string `path:"book-id" doc:"Book identifier" example:"sapiens"`
 		Body Book
 	}) (*struct{}, error) {
 		booksMu.Lock()
@@ -228,7 +228,7 @@ func (s *APIServer) RegisterDeleteBook(api huma.API) {
 		Tags:        []string{"Books"},
 	}, func(ctx context.Context, input *struct {
 		conditional.Params
-		ID string `path:"book-id"`
+		ID string `path:"book-id" doc:"Book identifier" example:"sapiens"`
 	}) (*struct{}, error) {
 		booksMu.Lock()
 		defer booksMu.Unlock()

--- a/echo.go
+++ b/echo.go
@@ -29,11 +29,11 @@ func (r *RequestInfo) Resolve(ctx huma.Context) []error {
 }
 
 type EchoModel struct {
-	Method  string            `json:"method" doc:"HTTP method used"`
+	Method  string            `json:"method" enum:"GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS" doc:"HTTP method used" example:"GET"`
 	Headers map[string]string `json:"headers" doc:"HTTP headers"`
-	Host    string            `json:"host,omitempty" doc:"Hostname and optional port"`
-	URL     string            `json:"url" doc:"Full URL"`
-	Path    string            `json:"path" doc:"URL path"`
+	Host    string            `json:"host,omitempty" doc:"Hostname and optional port" example:"api.rest.sh"`
+	URL     string            `json:"url" format:"uri" doc:"Full URL" example:"https://api.rest.sh/get?show_env=1"`
+	Path    string            `json:"path" doc:"URL path" example:"/get"`
 	Query   map[string]string `json:"query,omitempty" doc:"URL query parameters"`
 	Body    interface{}       `json:"body,omitempty" doc:"Raw request body, either a UTF-8 string or bytes"`
 	Parsed  interface{}       `json:"parsed,omitempty" doc:"Parsed request body"`
@@ -64,6 +64,10 @@ type EchoResponse struct {
 	Vary         string    `header:"Vary"`
 
 	Body EchoModel
+}
+
+type BodyResponse struct {
+	Body any
 }
 
 func (s *APIServer) echoHandler(ctx context.Context, input *struct {
@@ -127,6 +131,21 @@ func (s *APIServer) echoHandler(ctx context.Context, input *struct {
 	resp.ETag = quoteETag(etag)
 
 	return resp, nil
+}
+
+func (s *APIServer) RegisterBody(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "post-body",
+		Method:      http.MethodPost,
+		Path:        "/body",
+		Summary:     "Return the parsed request body",
+		Description: "Echo the parsed request body as the complete response body.",
+		Tags:        []string{"Echo"},
+	}, func(ctx context.Context, input *struct {
+		Body any `doc:"Request body to parse and echo"`
+	}) (*BodyResponse, error) {
+		return &BodyResponse{Body: input.Body}, nil
+	})
 }
 
 func (s *APIServer) RegisterEcho(api huma.API) {

--- a/example.go
+++ b/example.go
@@ -11,83 +11,83 @@ import (
 )
 
 type Resume struct {
-	Basics    Basics      `json:"basics"`
-	Work      []Work      `json:"work"`
-	Volunteer []Volunteer `json:"volunteer,omitempty"`
-	Education []Education `json:"education,omitempty"`
-	Skills    []Skill     `json:"skills,omitempty"`
-	Languages []Language  `json:"languages,omitempty"`
+	Basics    Basics      `json:"basics" doc:"Core profile and contact information"`
+	Work      []Work      `json:"work" minItems:"1" doc:"Professional work history"`
+	Volunteer []Volunteer `json:"volunteer,omitempty" doc:"Volunteer experience"`
+	Education []Education `json:"education,omitempty" doc:"Education history"`
+	Skills    []Skill     `json:"skills,omitempty" doc:"Skills and keywords"`
+	Languages []Language  `json:"languages,omitempty" doc:"Spoken languages"`
 }
 
 type Basics struct {
-	Name     string    `json:"name"`
-	Label    string    `json:"label,omitempty" example:"Web Developer"`
-	Email    string    `json:"email,omitempty" example:"thomas@gmail.com"`
-	Image    string    `json:"image,omitempty" doc:"URL (as per RFC 3986) to a image in JPEG or PNG format"`
+	Name     string    `json:"name" minLength:"1" example:"Thomas Davis" doc:"Full display name"`
+	Label    string    `json:"label,omitempty" minLength:"1" example:"Web Developer" doc:"Short professional headline"`
+	Email    string    `json:"email,omitempty" format:"email" example:"thomas@gmail.com" doc:"Contact email address"`
+	Image    string    `json:"image,omitempty" format:"uri" doc:"URL (as per RFC 3986) to an image in JPEG or PNG format" example:"https://example.com/avatar.jpg"`
 	Phone    string    `json:"phone,omitempty" doc:"Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"`
 	URL      string    `json:"url,omitempty" format:"uri" doc:"URL (as per RFC 3986) to your website, e.g. personal homepage"`
 	Summary  string    `json:"summary,omitempty" doc:"Write a short 2-3 sentence biography about yourself"`
-	Location Location  `json:"location,omitempty"`
-	Profiles []Profile `json:"profiles,omitempty"`
-	Updated  time.Time `json:"updated"`
-	Verified bool      `json:"verified"`
+	Location Location  `json:"location,omitempty" doc:"Primary location"`
+	Profiles []Profile `json:"profiles,omitempty" maxItems:"10" doc:"Online social or professional profiles"`
+	Updated  time.Time `json:"updated" doc:"Time when the resume data was last updated"`
+	Verified bool      `json:"verified" doc:"Whether this example profile has been verified" example:"true"`
 }
 
 type Location struct {
 	Address     string `json:"address,omitempty" doc:"To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."`
-	PostalCode  string `json:"postalCode,omitempty"`
-	City        string `json:"city,omitempty"`
-	CountryCode string `json:"countryCode,omitempty" doc:"code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"`
+	PostalCode  string `json:"postalCode,omitempty" example:"94105" doc:"Postal or ZIP code"`
+	City        string `json:"city,omitempty" example:"San Francisco" doc:"City or locality"`
+	CountryCode string `json:"countryCode,omitempty" minLength:"2" maxLength:"2" doc:"Code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN" example:"US"`
 	Region      string `json:"region,omitempty" doc:"The general region where you live. Can be a US state, or a province, for instance."`
 }
 
 type Profile struct {
-	Network  string `json:"network,omitempty" example:"Twitter"`
-	Username string `json:"username,omitempty" example:"neutralthoughts"`
+	Network  string `json:"network,omitempty" minLength:"1" example:"Twitter" doc:"Profile network or service name"`
+	Username string `json:"username,omitempty" minLength:"1" example:"neutralthoughts" doc:"Username on the profile network"`
 	URL      string `json:"url,omitempty" format:"uri" example:"http://twitter.example.com/neutralthoughts"`
 }
 
 type Work struct {
-	Name        string     `json:"name" example:"Facebook"`
+	Name        string     `json:"name" minLength:"1" example:"Facebook" doc:"Employer or organization name"`
 	Location    string     `json:"location,omitempty" example:"Menlo Park, CA"`
 	Description string     `json:"description,omitempty" example:"Social Media Company"`
-	Position    string     `json:"position" example:"Software Engineer"`
+	Position    string     `json:"position" minLength:"1" example:"Software Engineer" doc:"Job title or role"`
 	URL         string     `json:"url,omitempty" format:"uri" example:"https://facebook.com"`
-	StartDate   *time.Time `json:"startDate,omitempty"`
-	EndDate     *time.Time `json:"endDate,omitempty"`
+	StartDate   *time.Time `json:"startDate,omitempty" doc:"Role start date"`
+	EndDate     *time.Time `json:"endDate,omitempty" doc:"Role end date, omitted for current roles"`
 	Summary     string     `json:"summary,omitempty" doc:"Give an overview of your responsibilities at the company"`
-	Highlights  []string   `json:"highlights,omitempty" doc:"Specify multiple accomplishments"`
+	Highlights  []string   `json:"highlights,omitempty" maxItems:"10" doc:"Specify multiple accomplishments"`
 }
 
 type Volunteer struct {
-	Organization string     `json:"organization,omitempty"`
-	Position     string     `json:"position,omitempty"`
-	URL          string     `json:"url,omitempty"`
-	StartDate    *time.Time `json:"startDate,omitempty"`
-	EndDate      *time.Time `json:"endDate,omitempty"`
-	Summary      string     `json:"summary,omitempty"`
-	Highlights   []string   `json:"highlights,omitempty"`
+	Organization string     `json:"organization,omitempty" example:"Code for America" doc:"Volunteer organization name"`
+	Position     string     `json:"position,omitempty" example:"Mentor" doc:"Volunteer role"`
+	URL          string     `json:"url,omitempty" format:"uri" example:"https://www.codeforamerica.org"`
+	StartDate    *time.Time `json:"startDate,omitempty" doc:"Volunteer role start date"`
+	EndDate      *time.Time `json:"endDate,omitempty" doc:"Volunteer role end date"`
+	Summary      string     `json:"summary,omitempty" doc:"Overview of the volunteer work"`
+	Highlights   []string   `json:"highlights,omitempty" maxItems:"10" doc:"Notable volunteer accomplishments"`
 }
 
 type Education struct {
-	Institution string     `json:"institution,omitempty"`
-	Area        string     `json:"area,omitempty"`
-	StudyType   string     `json:"studyType,omitempty"`
-	StartDate   *time.Time `json:"startDate,omitempty"`
-	EndDate     *time.Time `json:"endDate,omitempty"`
-	Gpa         string     `json:"gpa,omitempty"`
-	Courses     []string   `json:"courses,omitempty"`
+	Institution string     `json:"institution,omitempty" example:"University of Example" doc:"School or institution name"`
+	Area        string     `json:"area,omitempty" example:"Computer Science" doc:"Field of study"`
+	StudyType   string     `json:"studyType,omitempty" enum:"High School,Bachelor,Master,Doctorate,Certificate" example:"Bachelor" doc:"Type of study or credential"`
+	StartDate   *time.Time `json:"startDate,omitempty" doc:"Education start date"`
+	EndDate     *time.Time `json:"endDate,omitempty" doc:"Education end date"`
+	Gpa         string     `json:"gpa,omitempty" example:"3.8" doc:"Grade point average or equivalent"`
+	Courses     []string   `json:"courses,omitempty" maxItems:"20" doc:"Relevant courses"`
 }
 
 type Skill struct {
-	Name     string   `json:"name,omitempty"`
-	Level    string   `json:"level,omitempty"`
-	Keywords []string `json:"keywords,omitempty"`
+	Name     string   `json:"name,omitempty" example:"Web Development" doc:"Skill category name"`
+	Level    string   `json:"level,omitempty" enum:"Beginner,Intermediate,Advanced,Expert" example:"Advanced" doc:"Proficiency level"`
+	Keywords []string `json:"keywords,omitempty" minItems:"1" maxItems:"20" doc:"Specific technologies or practices"`
 }
 
 type Language struct {
-	Language string `json:"language,omitempty"`
-	Fluency  string `json:"fluency,omitempty"`
+	Language string `json:"language,omitempty" example:"English" doc:"Language name"`
+	Fluency  string `json:"fluency,omitempty" enum:"Elementary,Limited working,Professional working,Full professional,Native or bilingual" example:"Native or bilingual" doc:"Language fluency"`
 }
 
 var example Resume

--- a/fixtures.go
+++ b/fixtures.go
@@ -692,7 +692,7 @@ func (s *APIServer) RegisterRedirects(api huma.API) {
 		Responses:     redirectRangeResponses(),
 	}, func(ctx context.Context, input *struct {
 		RequestInfo
-		URL        string `query:"url" required:"true" format:"uri" doc:"Absolute or relative redirect target" example:"https://example.com/next"`
+		URL        string `query:"url" required:"true" format:"uri-reference" doc:"Absolute or relative redirect target" example:"/get"`
 		StatusCode int    `query:"status_code" default:"302" minimum:"300" maximum:"399" doc:"3xx redirect status code to send" example:"307"`
 	}) (*struct{ Status int }, error) {
 		input.ctx.SetHeader("Location", input.URL)

--- a/fixtures.go
+++ b/fixtures.go
@@ -30,9 +30,9 @@ import (
 
 type TokenResponse struct {
 	Body struct {
-		Token     string `json:"token"`
-		TokenType string `json:"token_type"`
-		User      string `json:"user"`
+		Token     string `json:"token" doc:"Mock bearer token for documentation examples" example:"docs-token-alice"`
+		TokenType string `json:"token_type" enum:"Bearer" doc:"Token type" example:"Bearer"`
+		User      string `json:"user" doc:"Username from the submitted form" example:"alice"`
 	}
 }
 
@@ -64,16 +64,16 @@ func (s *APIServer) RegisterLogin(api huma.API) {
 }
 
 type UploadFile struct {
-	Field       string `json:"field"`
-	Filename    string `json:"filename"`
-	ContentType string `json:"content_type,omitempty"`
-	Size        int64  `json:"size"`
+	Field       string `json:"field" doc:"Multipart field name" example:"avatar"`
+	Filename    string `json:"filename" doc:"Uploaded filename" example:"avatar.png"`
+	ContentType string `json:"content_type,omitempty" doc:"Detected file content type" example:"image/png"`
+	Size        int64  `json:"size" minimum:"0" doc:"File size in bytes" example:"2048"`
 }
 
 type UploadResponse struct {
 	Body struct {
-		Fields map[string][]string `json:"fields"`
-		Files  []UploadFile        `json:"files"`
+		Fields map[string][]string `json:"fields" doc:"Non-file multipart fields grouped by field name"`
+		Files  []UploadFile        `json:"files" doc:"Uploaded file metadata"`
 	}
 }
 
@@ -127,9 +127,9 @@ func (s *APIServer) RegisterUploads(api huma.API) {
 
 type AuthResponse struct {
 	Body struct {
-		Authenticated bool   `json:"authenticated"`
-		Scheme        string `json:"scheme"`
-		Subject       string `json:"subject,omitempty"`
+		Authenticated bool   `json:"authenticated" doc:"Whether the mock authentication check succeeded" example:"true"`
+		Scheme        string `json:"scheme" enum:"basic,bearer,api-key-header,api-key-query" doc:"Authentication scheme that accepted the request" example:"bearer"`
+		Subject       string `json:"subject,omitempty" doc:"Authenticated username, token, or API key" example:"docs-token"`
 	}
 }
 
@@ -278,7 +278,7 @@ func (s *APIServer) RegisterAuthAPIKeyQuery(api huma.API) {
 		Tags:        []string{"Auth"},
 		Security:    []map[string][]string{{"apiKeyQuery": {}}},
 	}, func(ctx context.Context, input *struct {
-		APIKey string `query:"api_key" doc:"API key"`
+		APIKey string `query:"api_key" doc:"API key" example:"docs-query-key"`
 	}) (*AuthResponse, error) {
 		if input.APIKey == "" {
 			return nil, huma.Error401Unauthorized("missing api_key")
@@ -300,11 +300,11 @@ func parseBasic(header string) (string, string, bool) {
 }
 
 type Item struct {
-	ID      string    `json:"id"`
-	Name    string    `json:"name"`
-	Enabled bool      `json:"enabled"`
-	Tags    []string  `json:"tags,omitempty"`
-	Updated time.Time `json:"updated"`
+	ID      string    `json:"id" maxLength:"64" doc:"Stable item identifier; omit or leave empty when creating an item to have one generated" example:"alpha"`
+	Name    string    `json:"name" minLength:"1" maxLength:"120" doc:"Display name" example:"Alpha item"`
+	Enabled bool      `json:"enabled" doc:"Whether the item is enabled" example:"true"`
+	Tags    []string  `json:"tags,omitempty" maxItems:"10" uniqueItems:"true" doc:"Free-form item tags" example:"[\"docs\",\"example\"]"`
+	Updated time.Time `json:"updated" doc:"Time when the item was last updated"`
 }
 
 type ItemsResponse struct {
@@ -366,7 +366,7 @@ func (s *APIServer) RegisterGetItem(api huma.API) {
 		Summary:     "Get a sample item",
 		Tags:        []string{"Items"},
 	}, func(ctx context.Context, input *struct {
-		ID string `path:"item-id"`
+		ID string `path:"item-id" doc:"Item identifier" example:"alpha"`
 	}) (*ItemResponse, error) {
 		itemsMu.RLock()
 		defer itemsMu.RUnlock()
@@ -411,7 +411,7 @@ func (s *APIServer) RegisterPatchItem(api huma.API) {
 		Summary:     "Patch a sample item",
 		Tags:        []string{"Items"},
 	}, func(ctx context.Context, input *struct {
-		ID   string `path:"item-id"`
+		ID   string `path:"item-id" doc:"Item identifier" example:"alpha"`
 		Body map[string]any
 	}) (*ItemResponse, error) {
 		itemsMu.Lock()
@@ -448,7 +448,7 @@ func (s *APIServer) RegisterDeleteItem(api huma.API) {
 		Summary:     "Delete a sample item",
 		Tags:        []string{"Items"},
 	}, func(ctx context.Context, input *struct {
-		ID string `path:"item-id"`
+		ID string `path:"item-id" doc:"Item identifier" example:"alpha"`
 	}) (*struct{}, error) {
 		itemsMu.Lock()
 		defer itemsMu.Unlock()
@@ -474,8 +474,8 @@ func (s *APIServer) RegisterFlaky(api huma.API) {
 		Summary:     "Fail a configurable number of times, then succeed",
 		Tags:        []string{"Reliability"},
 	}, func(ctx context.Context, input *struct {
-		Failures int    `query:"failures" default:"2" minimum:"0" maximum:"20"`
-		Key      string `query:"key" default:"default"`
+		Failures int    `query:"failures" default:"2" minimum:"0" maximum:"20" doc:"Number of failed attempts before returning success" example:"2"`
+		Key      string `query:"key" default:"default" doc:"Counter key used to isolate retry sequences" example:"docs-demo"`
 	}) (*struct {
 		Status int
 		Body   map[string]any
@@ -663,7 +663,7 @@ func (s *APIServer) RegisterRedirects(api huma.API) {
 			Responses:     redirectResponses(http.StatusFound),
 		}, func(ctx context.Context, input *struct {
 			RequestInfo
-			N int `path:"n" minimum:"1" maximum:"20"`
+			N int `path:"n" minimum:"1" maximum:"20" doc:"Number of redirects to follow before reaching /get" example:"3"`
 		}) (*struct{ Status int }, error) {
 			n := input.N - 1
 			next := "/get"
@@ -692,8 +692,8 @@ func (s *APIServer) RegisterRedirects(api huma.API) {
 		Responses:     redirectRangeResponses(),
 	}, func(ctx context.Context, input *struct {
 		RequestInfo
-		URL        string `query:"url" required:"true"`
-		StatusCode int    `query:"status_code" default:"302" minimum:"300" maximum:"399"`
+		URL        string `query:"url" required:"true" format:"uri" doc:"Absolute or relative redirect target" example:"https://example.com/next"`
+		StatusCode int    `query:"status_code" default:"302" minimum:"300" maximum:"399" doc:"3xx redirect status code to send" example:"307"`
 	}) (*struct{ Status int }, error) {
 		input.ctx.SetHeader("Location", input.URL)
 		return &struct{ Status int }{Status: input.StatusCode}, nil
@@ -717,7 +717,7 @@ func (s *APIServer) RegisterETagFixture(api huma.API) {
 		Tags:        []string{"Caching"},
 	}, func(ctx context.Context, input *struct {
 		RequestInfo
-		ETag string `path:"etag"`
+		ETag string `path:"etag" doc:"Opaque ETag value to return" example:"docs-cache"`
 	}) (*struct{}, error) {
 		etag := `"` + input.ETag + `"`
 		input.ctx.SetHeader("ETag", etag)
@@ -772,8 +772,8 @@ func (s *APIServer) RegisterBytes(api huma.API) {
 		Summary:     "Return random bytes",
 		Tags:        []string{"Binary"},
 	}, func(ctx context.Context, input *struct {
-		N    int `path:"n" minimum:"1" maximum:"1048576"`
-		Seed int `query:"seed" doc:"Optional deterministic seed"`
+		N    int `path:"n" minimum:"1" maximum:"1048576" doc:"Number of bytes to return" example:"1024"`
+		Seed int `query:"seed" doc:"Optional deterministic seed" example:"42"`
 	}) (*BinaryResponse, error) {
 		data, err := makeBytes(input.N, input.Seed)
 		if err != nil {
@@ -803,9 +803,9 @@ func (s *APIServer) RegisterStreamBytes(api huma.API) {
 		Tags:        []string{"Binary"},
 	}, func(ctx context.Context, input *struct {
 		RequestInfo
-		N         int `path:"n" minimum:"1" maximum:"1048576"`
-		ChunkSize int `query:"chunk_size" default:"1024" minimum:"1" maximum:"65536"`
-		Seed      int `query:"seed"`
+		N         int `path:"n" minimum:"1" maximum:"1048576" doc:"Total number of bytes to stream" example:"4096"`
+		ChunkSize int `query:"chunk_size" default:"1024" minimum:"1" maximum:"65536" doc:"Maximum bytes written per chunk" example:"1024"`
+		Seed      int `query:"seed" doc:"Optional deterministic seed" example:"42"`
 	}) (*struct{}, error) {
 		input.ctx.SetHeader("Content-Type", "application/octet-stream")
 		data, err := makeBytes(input.N, input.Seed)
@@ -834,7 +834,7 @@ func (s *APIServer) RegisterRange(api huma.API) {
 		Tags:        []string{"Binary"},
 	}, func(ctx context.Context, input *struct {
 		RequestInfo
-		N int `path:"n" minimum:"1" maximum:"1048576"`
+		N int `path:"n" minimum:"1" maximum:"1048576" doc:"Number of bytes in the virtual resource" example:"1024"`
 	}) (*BinaryResponse, error) {
 		data, err := makeBytes(input.N, 1)
 		if err != nil {
@@ -882,10 +882,10 @@ func (s *APIServer) RegisterDrip(api huma.API) {
 		Tags:        []string{"Binary"},
 	}, func(ctx context.Context, input *struct {
 		RequestInfo
-		NumBytes int    `query:"numbytes" default:"10" minimum:"1" maximum:"10000"`
-		Duration string `query:"duration" default:"2s"`
-		Delay    string `query:"delay" default:"0s"`
-		Code     int    `query:"code" default:"200" minimum:"100" maximum:"599"`
+		NumBytes int    `query:"numbytes" default:"10" minimum:"1" maximum:"10000" doc:"Number of bytes to stream" example:"10"`
+		Duration string `query:"duration" default:"2s" doc:"Total duration over which bytes are emitted" example:"2s"`
+		Delay    string `query:"delay" default:"0s" doc:"Delay before streaming begins" example:"500ms"`
+		Code     int    `query:"code" default:"200" minimum:"100" maximum:"599" doc:"HTTP status code to return" example:"200"`
 	}) (*struct{}, error) {
 		delay, err := time.ParseDuration(input.Delay)
 		if err != nil {
@@ -1030,7 +1030,7 @@ func (s *APIServer) RegisterFormats(api huma.API) {
 		Summary:     "Return data using a specific media type",
 		Tags:        []string{"Content"},
 	}, func(ctx context.Context, input *struct {
-		Format string `path:"format" enum:"json,yaml,cbor,vendor-json"`
+		Format string `path:"format" enum:"json,yaml,cbor,vendor-json" doc:"Response format to encode" example:"json"`
 	}) (*struct {
 		ContentType string `header:"Content-Type"`
 		Body        []byte

--- a/main.go
+++ b/main.go
@@ -60,27 +60,27 @@ type CachedModel struct {
 }
 
 type ImageItem struct {
-	Name   string `json:"name"`
-	Format string `json:"format" enum:"jpeg,webp,gif,png,heic"`
-	Self   string `json:"self" format:"uri-reference"`
+	Name   string `json:"name" doc:"Human-readable image fixture name" example:"Dragonfly"`
+	Format string `json:"format" enum:"jpeg,webp,gif,png,heic" doc:"Image format returned by the fixture" example:"jpeg"`
+	Self   string `json:"self" format:"uri-reference" doc:"Relative URL for this image fixture" example:"/image/jpeg"`
 }
 
 type SubObject struct {
-	Binary     []byte    `json:"binary"`
-	BinaryLong []byte    `json:"binary_long"`
-	Date       time.Time `json:"date"`
-	DateTime   time.Time `json:"date_time"`
-	URL        string    `json:"url" format:"uri"`
+	Binary     []byte    `json:"binary" doc:"Small binary payload encoded as base64 in JSON" minLength:"1"`
+	BinaryLong []byte    `json:"binary_long" doc:"Longer binary payload encoded as base64 in JSON" minLength:"1"`
+	Date       time.Time `json:"date" doc:"Calendar date represented as an RFC 3339 timestamp"`
+	DateTime   time.Time `json:"date_time" doc:"Full timestamp with timezone"`
+	URL        string    `json:"url" format:"uri" doc:"Absolute URL example" example:"https://rest.sh/"`
 }
 
 type TypesModel struct {
-	Nullable *struct{} `json:"nullable"`
-	Boolean  bool      `json:"boolean"`
-	Integer  int64     `json:"integer"`
-	Number   float64   `json:"number"`
-	String   string    `json:"string"`
-	Tags     []string  `json:"tags"`
-	Object   SubObject `json:"object"`
+	Nullable *struct{} `json:"nullable" doc:"Nullable object field; this response intentionally returns null"`
+	Boolean  bool      `json:"boolean" doc:"Boolean example value" example:"true"`
+	Integer  int64     `json:"integer" minimum:"0" maximum:"100" doc:"Integer example with validation bounds" example:"42"`
+	Number   float64   `json:"number" minimum:"0" maximum:"1000" multipleOf:"0.01" doc:"Floating point example with precision constraints" example:"123.45"`
+	String   string    `json:"string" minLength:"1" maxLength:"120" doc:"Plain UTF-8 string example" example:"Hello, world!"`
+	Tags     []string  `json:"tags" minItems:"1" maxItems:"5" uniqueItems:"true" doc:"Short list of descriptive tags" example:"[\"example\",\"short\"]"`
+	Object   SubObject `json:"object" doc:"Nested object showing binary, date-time, and URI fields"`
 }
 
 type TypesResponse struct {
@@ -137,8 +137,8 @@ func (s *APIServer) RegisterCached(api huma.API) {
 		Description: "Cached response example",
 		Tags:        []string{"Caching"},
 	}, func(ctx context.Context, input *struct {
-		Seconds int  `path:"seconds" minimum:"1" maximum:"300" doc:"Number of seconds to cache"`
-		Private bool `query:"private" doc:"Disabled shared caches like CDNs"`
+		Seconds int  `path:"seconds" minimum:"1" maximum:"300" doc:"Number of seconds to cache" example:"60"`
+		Private bool `query:"private" doc:"Disable shared caches like CDNs" example:"false"`
 	}) (*CachedResponse, error) {
 		header := fmt.Sprintf("max-age=%d", input.Seconds)
 		if input.Private {
@@ -238,9 +238,9 @@ func (s *APIServer) RegisterStatus(api huma.API) {
 		DefaultStatus: http.StatusOK,
 		Responses:     statusFixtureResponses(),
 	}, func(ctx context.Context, input *struct {
-		Code       int    `path:"code" minimum:"100" maximum:"599" doc:"Status code to return"`
-		RetryAfter string `query:"retry-after" doc:"Retry-After header value"`
-		XRetryIn   string `query:"x-retry-in" doc:"X-Retry-In header value"`
+		Code       int    `path:"code" minimum:"100" maximum:"599" doc:"Status code to return" example:"418"`
+		RetryAfter string `query:"retry-after" doc:"Retry-After header value" example:"120"`
+		XRetryIn   string `query:"x-retry-in" doc:"X-Retry-In header value" example:"2m"`
 	}) (*StatusResponse, error) {
 		return &StatusResponse{
 			Status:     input.Code,
@@ -251,7 +251,7 @@ func (s *APIServer) RegisterStatus(api huma.API) {
 }
 
 type ListImagesResponse struct {
-	Link string `header:"Link"`
+	Link string `header:"Link" doc:"RFC 8288 pagination links"`
 	Body []ImageItem
 }
 
@@ -263,11 +263,11 @@ func (s *APIServer) RegisterListImages(api huma.API) {
 		Description: "List available images",
 		Tags:        []string{"Images"},
 	}, func(ctx context.Context, input *struct {
-		Cursor  string `query:"cursor" doc:"Pagination cursor"`
-		Format  string `query:"format" enum:"jpeg,webp,gif,png,heic" doc:"Filter by image format"`
-		Search  string `query:"search" doc:"Case-insensitive search over image names"`
-		Limit   int    `query:"limit" minimum:"1" maximum:"5" doc:"Maximum number of images to return"`
-		PerPage int    `query:"per_page" minimum:"1" maximum:"5" doc:"Alias for limit"`
+		Cursor  string `query:"cursor" doc:"Pagination cursor" example:"abc123"`
+		Format  string `query:"format" enum:"jpeg,webp,gif,png,heic" doc:"Filter by image format" example:"png"`
+		Search  string `query:"search" minLength:"1" maxLength:"100" doc:"Case-insensitive search over image names" example:"station"`
+		Limit   int    `query:"limit" minimum:"1" maximum:"5" doc:"Maximum number of images to return" example:"2"`
+		PerPage int    `query:"per_page" minimum:"1" maximum:"5" doc:"Alias for limit" example:"2"`
 	}) (*ListImagesResponse, error) {
 		// Return different pages based on the cursor.
 		resp := &ListImagesResponse{}
@@ -333,7 +333,7 @@ func filterImages(images []ImageItem, format, search string, limit, perPage int)
 }
 
 type GetImageResponse struct {
-	ContentType string `header:"Content-Type"`
+	ContentType string `header:"Content-Type" doc:"Image media type"`
 	Body        []byte
 }
 
@@ -345,7 +345,7 @@ func (s *APIServer) RegisterGetImage(api huma.API) {
 		Description: "Get an image",
 		Tags:        []string{"Images"},
 	}, func(ctx context.Context, i *struct {
-		Type string `path:"type" enum:"jpeg,webp,png,gif,heic"`
+		Type string `path:"type" enum:"jpeg,webp,png,gif,heic" doc:"Image format to return" example:"png"`
 	}) (*GetImageResponse, error) {
 		return imageResponse(i.Type), nil
 	})

--- a/sse.go
+++ b/sse.go
@@ -16,34 +16,34 @@ import (
 // MetricEvent represents a snapshot of simulated server metrics.
 type MetricEvent struct {
 	Timestamp      time.Time `json:"timestamp" doc:"Time the metrics were sampled"`
-	CPUPercent     float64   `json:"cpu_percent" doc:"CPU utilization percentage" minimum:"0" maximum:"100"`
-	MemoryPercent  float64   `json:"memory_percent" doc:"Memory utilization percentage" minimum:"0" maximum:"100"`
-	ActiveConns    int       `json:"active_connections" doc:"Number of active HTTP connections"`
-	RequestsPerSec float64   `json:"requests_per_second" doc:"Inbound request rate"`
-	Region         string    `json:"region" doc:"Data center region reporting metrics"`
+	CPUPercent     float64   `json:"cpu_percent" doc:"CPU utilization percentage" minimum:"0" maximum:"100" example:"62.4"`
+	MemoryPercent  float64   `json:"memory_percent" doc:"Memory utilization percentage" minimum:"0" maximum:"100" example:"71.2"`
+	ActiveConns    int       `json:"active_connections" minimum:"0" doc:"Number of active HTTP connections" example:"96"`
+	RequestsPerSec float64   `json:"requests_per_second" minimum:"0" maximum:"2000" doc:"Inbound request rate" example:"421.5"`
+	Region         string    `json:"region" enum:"us-east-1,us-west-2,eu-west-1,ap-southeast-1" doc:"Data center region reporting metrics" example:"us-west-2"`
 }
 
 // AlertEvent is emitted when a metric crosses a warning or critical threshold.
 type AlertEvent struct {
 	Timestamp time.Time `json:"timestamp" doc:"Time the alert was raised"`
-	Severity  string    `json:"severity" enum:"warning,critical" doc:"Alert severity level"`
-	Metric    string    `json:"metric" doc:"Name of the metric that triggered the alert"`
-	Value     float64   `json:"value" doc:"Current value of the metric"`
-	Threshold float64   `json:"threshold" doc:"Threshold that was exceeded"`
-	Message   string    `json:"message" doc:"Human-readable alert description"`
+	Severity  string    `json:"severity" enum:"warning,critical" doc:"Alert severity level" example:"warning"`
+	Metric    string    `json:"metric" enum:"cpu_percent,memory_percent" doc:"Name of the metric that triggered the alert" example:"cpu_percent"`
+	Value     float64   `json:"value" minimum:"0" doc:"Current value of the metric" example:"82.3"`
+	Threshold float64   `json:"threshold" minimum:"0" doc:"Threshold that was exceeded" example:"80"`
+	Message   string    `json:"message" doc:"Human-readable alert description" example:"cpu_percent is critically high at 82.3% (threshold: 80%)"`
 }
 
 // DocsUser identifies a user in docs-oriented stream examples.
 type DocsUser struct {
-	ID   string `json:"id" doc:"User ID"`
-	Name string `json:"name" doc:"Display name"`
+	ID   string `json:"id" minLength:"1" doc:"User ID" example:"u_123"`
+	Name string `json:"name" minLength:"1" doc:"Display name" example:"Alice"`
 }
 
 // DocsEvent is a simple event shape for streaming documentation examples.
 type DocsEvent struct {
-	Type      string    `json:"type" enum:"login,update,logout" doc:"Event type"`
+	Type      string    `json:"type" enum:"login,update,logout" doc:"Event type" example:"login"`
 	User      DocsUser  `json:"user" doc:"User associated with the event"`
-	Message   string    `json:"message" doc:"Human-readable message"`
+	Message   string    `json:"message" doc:"Human-readable message" example:"login event for Alice"`
 	Timestamp time.Time `json:"timestamp" doc:"Event timestamp"`
 }
 

--- a/sse.go
+++ b/sse.go
@@ -26,7 +26,7 @@ type MetricEvent struct {
 // AlertEvent is emitted when a metric crosses a warning or critical threshold.
 type AlertEvent struct {
 	Timestamp time.Time `json:"timestamp" doc:"Time the alert was raised"`
-	Severity  string    `json:"severity" enum:"warning,critical" doc:"Alert severity level" example:"warning"`
+	Severity  string    `json:"severity" enum:"warning,critical" doc:"Alert severity level" example:"critical"`
 	Metric    string    `json:"metric" enum:"cpu_percent,memory_percent" doc:"Name of the metric that triggered the alert" example:"cpu_percent"`
 	Value     float64   `json:"value" minimum:"0" doc:"Current value of the metric" example:"82.3"`
 	Threshold float64   `json:"threshold" minimum:"0" doc:"Threshold that was exceeded" example:"80"`


### PR DESCRIPTION
## Summary

- Add `POST /body` as a compact endpoint that returns the parsed request body directly.
- Enrich OpenAPI schema metadata across echo, books, examples, fixtures, images, and streaming models.
- Add regression coverage for `/body` and schema metadata exposed in the generated OpenAPI document.

## Impact

This lets Restish users run commands like `restish api.rest.sh/body some: data` and get back only the parsed payload, without needing `-f body.parsed` against the full echo response. The schema/doc updates improve generated docs and client examples without changing the runtime behavior of existing endpoints.

## Validation

- `env GOCACHE=/tmp/apibin-gocache go test ./...`