### PR TITLE
Bump Huma and use Go 1.25 Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.18 as build
+FROM golang:1.25-alpine AS build
 
 WORKDIR /build
 COPY go.mod go.sum ./


### PR DESCRIPTION
Replacement for PR #10 because the fork branch now has maintainer edits disabled, so the deploy follow-up could not be pushed there.

Summary:
- Bump Huma to v2.37.3 to fix float multipleOf validation for decimal book ratings.
- Keep Huma-native echo Body/RawBody parsing and mark echo request bodies optional after registration.
- Add regression tests for decimal ratings and optional echo request-body OpenAPI docs.
- Update the Docker build stage to Go 1.25 so DigitalOcean and image builds can parse/build the new module graph.

Verification:
- env GOCACHE=/tmp/apibin-gocache go build ./...
- env GOCACHE=/tmp/apibin-gocache go test ./...
- env GOCACHE=/tmp/apibin-gocache go test -race ./... before the Dockerfile-only follow-up
- Manual smoke checks for PATCH /books/the-fabric-of-the-cosmos, GET /anything/foo, HEAD /head, POST /post, and OpenAPI requestBody output

Note: local Docker image build was not run because the Docker daemon is not available in this environment.